### PR TITLE
Bump to latest versions defined in provenance release 1.5.0.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,10 +1,10 @@
 object Versions {
-    const val cosmos = "0.42.4"
-    const val wasmd = "v0.16.0"
-    const val pbProto = "1.3.0"
+    const val cosmos = "0.42.6"
+    const val wasmd = "v0.17.0"
+    const val pbProto = "1.5.0"
     const val protobuf = "3.6.1"
     const val protoUtil = "0.1.5"
-    const val grpc = "1.32.2"
+    const val grpc = "1.39.0"
     const val kotlin = "1.4.30"
     const val springboot = "2.3.5.RELEASE"
 

--- a/pb-proto-java/src/main/proto/cosmos/base/tendermint/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/tendermint/v1beta1/query.proto
@@ -116,13 +116,14 @@ message GetNodeInfoResponse {
 
 // VersionInfo is the type for the GetNodeInfoResponse message.
 message VersionInfo {
-  string          name       = 1;
-  string          app_name   = 2;
-  string          version    = 3;
-  string          git_commit = 4;
-  string          build_tags = 5;
-  string          go_version = 6;
-  repeated Module build_deps = 7;
+  string          name               = 1;
+  string          app_name           = 2;
+  string          version            = 3;
+  string          git_commit         = 4;
+  string          build_tags         = 5;
+  string          go_version         = 6;
+  repeated Module build_deps         = 7;
+  string          cosmos_sdk_version = 8;
 }
 
 // Module is the type for VersionInfo

--- a/pb-proto-java/src/main/proto/provenance/attribute/v1/attribute.proto
+++ b/pb-proto-java/src/main/proto/provenance/attribute/v1/attribute.proto
@@ -59,9 +59,29 @@ message EventAttributeAdd {
   string owner   = 5;
 }
 
+// EventAttributeUpdate event emitted when attribute is updated
+message EventAttributeUpdate {
+  string name           = 1;
+  string original_value = 2;
+  string original_type  = 3;
+  string update_value   = 4;
+  string update_type    = 5;
+  string account        = 6;
+  string owner          = 7;
+}
+
 // EventAttributeDelete event emitted when attribute is deleted
 message EventAttributeDelete {
   string name    = 1;
   string account = 2;
   string owner   = 3;
+}
+
+// EventAttributeDistinctDelete event emitted when attribute is deleted with matching value
+message EventAttributeDistinctDelete {
+  string name           = 1;
+  string value          = 2;
+  string attribute_type = 3;
+  string account        = 4;
+  string owner          = 5;
 }

--- a/pb-proto-java/src/main/proto/provenance/attribute/v1/tx.proto
+++ b/pb-proto-java/src/main/proto/provenance/attribute/v1/tx.proto
@@ -14,8 +14,14 @@ service Msg {
   // AddAttribute defines a method to verify a particular invariance.
   rpc AddAttribute(MsgAddAttributeRequest) returns (MsgAddAttributeResponse);
 
+  // UpdateAttribute defines a method to verify a particular invariance.
+  rpc UpdateAttribute(MsgUpdateAttributeRequest) returns (MsgUpdateAttributeResponse);
+
   // DeleteAttribute defines a method to verify a particular invariance.
   rpc DeleteAttribute(MsgDeleteAttributeRequest) returns (MsgDeleteAttributeResponse);
+
+  // DeleteDistinctAttribute defines a method to verify a particular invariance.
+  rpc DeleteDistinctAttribute(MsgDeleteDistinctAttributeRequest) returns (MsgDeleteDistinctAttributeResponse);
 }
 
 // MsgAddAttributeRequest defines an sdk.Msg type that is used to add a new attribute to an account
@@ -41,6 +47,33 @@ message MsgAddAttributeRequest {
 // MsgAddAttributeResponse defines the Msg/Vote response type.
 message MsgAddAttributeResponse {}
 
+// MsgUpdateAttributeRequest defines an sdk.Msg type that is used to update an existing attribute to an account
+// Attributes may only be set in an account by the account that the attribute name resolves to.
+message MsgUpdateAttributeRequest {
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_stringer) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
+
+  // The attribute name.
+  string name = 1;
+  // The original attribute value.
+  bytes original_value = 2;
+  // The update attribute value.
+  bytes update_value = 3;
+  // The original attribute value type.
+  AttributeType original_attribute_type = 4;
+  // The update attribute value type.
+  AttributeType update_attribute_type = 5;
+  // The account to add the attribute to.
+  string account = 6;
+  // The address that the name must resolve to.
+  string owner = 7;
+}
+
+// MsgUpdateAttributeResponse defines the Msg/Vote response type.
+message MsgUpdateAttributeResponse {}
+
 // MsgDeleteAttributeRequest defines a message to delete an attribute from an account
 // Attributes may only be remove from an account by the account that the attribute name resolves to.
 message MsgDeleteAttributeRequest {
@@ -59,3 +92,24 @@ message MsgDeleteAttributeRequest {
 
 // MsgDeleteAttributeResponse defines the Msg/Vote response type.
 message MsgDeleteAttributeResponse {}
+
+// MsgDeleteDistinctAttributeRequest defines a message to delete an attribute with matching name, value, and type from
+// an account Attributes may only be remove from an account by the account that the attribute name resolves to.
+message MsgDeleteDistinctAttributeRequest {
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_stringer) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
+
+  // The attribute name.
+  string name = 1;
+  // The attribute value.
+  bytes value = 2;
+  // The account to add the attribute to.
+  string account = 3;
+  // The address that the name must resolve to.
+  string owner = 4;
+}
+
+// MsgDeleteDistinctAttributeResponse defines the Msg/Vote response type.
+message MsgDeleteDistinctAttributeResponse {}

--- a/pb-proto-java/src/main/proto/provenance/metadata/v1/tx.proto
+++ b/pb-proto-java/src/main/proto/provenance/metadata/v1/tx.proto
@@ -53,6 +53,12 @@ service Msg {
   rpc DeleteContractSpecification(MsgDeleteContractSpecificationRequest)
       returns (MsgDeleteContractSpecificationResponse);
 
+  // AddContractSpecToScopeSpec adds contract specification to a scope specification.
+  rpc AddContractSpecToScopeSpec(MsgAddContractSpecToScopeSpecRequest) returns (MsgAddContractSpecToScopeSpecResponse);
+  // DeleteContractSpecFromScopeSpec deletes a contract specification from a scope specification.
+  rpc DeleteContractSpecFromScopeSpec(MsgDeleteContractSpecFromScopeSpecRequest)
+      returns (MsgDeleteContractSpecFromScopeSpecResponse);
+
   // WriteRecordSpecification adds or updates a record specification.
   rpc WriteRecordSpecification(MsgWriteRecordSpecificationRequest) returns (MsgWriteRecordSpecificationResponse);
   // DeleteRecordSpecification deletes a record specification.
@@ -401,6 +407,59 @@ message MsgWriteContractSpecificationResponse {
   // updated.
   ContractSpecIdInfo contract_spec_id_info = 1 [(gogoproto.moretags) = "yaml:\"contract_spec_id_info\""];
 }
+
+// MsgAddContractSpecToScopeSpecRequest is the request type for the Msg/AddContractSpecToScopeSpec RPC method.
+message MsgAddContractSpecToScopeSpecRequest {
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_stringer) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
+
+  // MetadataAddress for the contract specification to add.
+  bytes contract_specification_id = 1 [
+    (gogoproto.nullable)   = false,
+    (gogoproto.customtype) = "MetadataAddress",
+    (gogoproto.moretags)   = "yaml:\"specification_id\""
+  ];
+
+  // MetadataAddress for the scope specification to add contract specification to.
+  bytes scope_specification_id = 2 [
+    (gogoproto.nullable)   = false,
+    (gogoproto.customtype) = "MetadataAddress",
+    (gogoproto.moretags)   = "yaml:\"specification_id\""
+  ];
+  repeated string signers = 3;
+}
+
+// MsgAddContractSpecToScopeSpecResponse is the response type for the Msg/AddContractSpecToScopeSpec RPC method.
+message MsgAddContractSpecToScopeSpecResponse {}
+
+// MsgDeleteContractSpecFromScopeSpecRequest is the request type for the Msg/DeleteContractSpecFromScopeSpec RPC method.
+message MsgDeleteContractSpecFromScopeSpecRequest {
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_stringer) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
+
+  // MetadataAddress for the contract specification to add.
+  bytes contract_specification_id = 1 [
+    (gogoproto.nullable)   = false,
+    (gogoproto.customtype) = "MetadataAddress",
+    (gogoproto.moretags)   = "yaml:\"specification_id\""
+  ];
+
+  // MetadataAddress for the scope specification to add contract specification to.
+  bytes scope_specification_id = 2 [
+    (gogoproto.nullable)   = false,
+    (gogoproto.customtype) = "MetadataAddress",
+    (gogoproto.moretags)   = "yaml:\"specification_id\""
+  ];
+  repeated string signers = 3;
+}
+
+// MsgDeleteContractSpecFromScopeSpecResponse is the response type for the Msg/DeleteContractSpecFromScopeSpec RPC
+// method.
+message MsgDeleteContractSpecFromScopeSpecResponse {}
 
 // MsgDeleteContractSpecificationRequest is the request type for the Msg/DeleteContractSpecification RPC method.
 message MsgDeleteContractSpecificationRequest {


### PR DESCRIPTION
Associated versions pulled from https://github.com/provenance-io/provenance/releases/tag/v1.5.0.