### PR TITLE
Bump to provenance 1.7.0.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ buildscript {
     dependencies {
         classpath("org.jetbrains.kotlin", "kotlin-gradle-plugin", Versions.kotlin)
         classpath("org.jetbrains.kotlin", "kotlin-allopen", Versions.kotlin)
-        classpath("org.springframework.boot", "spring-boot-gradle-plugin", Versions.springboot)
         classpath("org.jlleitschuh.gradle", "ktlint-gradle", Versions.ktlintPlugin)
         classpath("com.google.protobuf", "protobuf-gradle-plugin", Versions.protobufPlugin)
     }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,12 +1,11 @@
 object Versions {
-    const val cosmos = "0.42.6"
-    const val wasmd = "v0.17.0"
-    const val pbProto = "1.5.0"
+    const val cosmos = "0.44.0"
+    const val wasmd = "v0.19.0"
+    const val pbProto = "1.7.0"
     const val protobuf = "3.6.1"
     const val protoUtil = "0.1.5"
     const val grpc = "1.39.0"
     const val kotlin = "1.4.30"
-    const val springboot = "2.3.5.RELEASE"
 
     // plugins
     const val ktlintPlugin = "9.4.1"

--- a/pb-proto-java/build.gradle.kts
+++ b/pb-proto-java/build.gradle.kts
@@ -84,7 +84,7 @@ val downloadAndUnzipProvenanceProtos = tasks.create<Copy>("downloadAndUnzipProve
 }
 
 val downloadWasmProtos = tasks.create<Download>("downloadWasmProtos") {
-    src("https://github.com/CosmWasm/wasmd/archive/refs/tags/${Versions.wasmd}.tar.gz")
+    src("https://github.com/provenance-io/wasmd/archive/refs/tags/${Versions.wasmd}.tar.gz")
     dest(File(buildDir, "${Versions.wasmd}.tar.gz"))
     onlyIfModified(true)
 }

--- a/pb-proto-java/src/main/proto/cosmos/auth/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/auth/v1beta1/query.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package cosmos.auth.v1beta1;
 
+import "cosmos/base/query/v1beta1/pagination.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 import "google/api/annotations.proto";
@@ -11,6 +12,11 @@ option go_package = "github.com/cosmos/cosmos-sdk/x/auth/types";
 
 // Query defines the gRPC querier service.
 service Query {
+  // Accounts returns all the existing accounts
+  rpc Accounts(QueryAccountsRequest) returns (QueryAccountsResponse) {
+    option (google.api.http).get = "/cosmos/auth/v1beta1/accounts";
+  }
+
   // Account returns account details based on address.
   rpc Account(QueryAccountRequest) returns (QueryAccountResponse) {
     option (google.api.http).get = "/cosmos/auth/v1beta1/accounts/{address}";
@@ -20,6 +26,21 @@ service Query {
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (google.api.http).get = "/cosmos/auth/v1beta1/params";
   }
+}
+
+// QueryAccountsRequest is the request type for the Query/Accounts RPC method.
+message QueryAccountsRequest {
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
+
+// QueryAccountsResponse is the response type for the Query/Accounts RPC method.
+message QueryAccountsResponse {
+  // accounts are the existing accounts
+  repeated google.protobuf.Any accounts = 1 [(cosmos_proto.accepts_interface) = "AccountI"];
+
+  // pagination defines the pagination in the response.
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
 // QueryAccountRequest is the request type for the Query/Account RPC method.

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/authz.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/authz.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+package cosmos.authz.v1beta1;
+
+import "cosmos_proto/cosmos.proto";
+import "google/protobuf/timestamp.proto";
+import "gogoproto/gogo.proto";
+import "google/protobuf/any.proto";
+
+option go_package                      = "github.com/cosmos/cosmos-sdk/x/authz";
+option (gogoproto.goproto_getters_all) = false;
+
+// GenericAuthorization gives the grantee unrestricted permissions to execute
+// the provided method on behalf of the granter's account.
+message GenericAuthorization {
+  option (cosmos_proto.implements_interface) = "Authorization";
+
+  // Msg, identified by it's type URL, to grant unrestricted permissions to execute
+  string msg = 1;
+}
+
+// Grant gives permissions to execute
+// the provide method with expiration time.
+message Grant {
+  google.protobuf.Any       authorization = 1 [(cosmos_proto.accepts_interface) = "Authorization"];
+  google.protobuf.Timestamp expiration    = 2 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+}

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/event.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/event.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package cosmos.authz.v1beta1;
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/authz";
+
+// EventGrant is emitted on Msg/Grant
+message EventGrant {
+  // Msg type URL for which an autorization is granted
+  string msg_type_url = 2;
+  // Granter account address
+  string granter = 3;
+  // Grantee account address
+  string grantee = 4;
+}
+
+// EventRevoke is emitted on Msg/Revoke
+message EventRevoke {
+  // Msg type URL for which an autorization is revoked
+  string msg_type_url = 2;
+  // Granter account address
+  string granter = 3;
+  // Grantee account address
+  string grantee = 4;
+}

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/genesis.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/genesis.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package cosmos.authz.v1beta1;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/authz";
+
+// GenesisState defines the authz module's genesis state.
+message GenesisState {
+  repeated GrantAuthorization authorization = 1 [(gogoproto.nullable) = false];
+}
+
+// GrantAuthorization defines the GenesisState/GrantAuthorization type.
+message GrantAuthorization {
+  string granter = 1;
+  string grantee = 2;
+
+  google.protobuf.Any       authorization = 3 [(cosmos_proto.accepts_interface) = "Authorization"];
+  google.protobuf.Timestamp expiration    = 4 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+}

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/query.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+package cosmos.authz.v1beta1;
+
+import "google/api/annotations.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "cosmos/authz/v1beta1/authz.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/authz";
+
+// Query defines the gRPC querier service.
+service Query {
+  // Returns list of `Authorization`, granted to the grantee by the granter.
+  rpc Grants(QueryGrantsRequest) returns (QueryGrantsResponse) {
+    option (google.api.http).get = "/cosmos/authz/v1beta1/grants";
+  }
+}
+
+// QueryGrantsRequest is the request type for the Query/Grants RPC method.
+message QueryGrantsRequest {
+  string granter = 1;
+  string grantee = 2;
+  // Optional, msg_type_url, when set, will query only grants matching given msg type.
+  string msg_type_url = 3;
+  // pagination defines an pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 4;
+}
+
+// QueryGrantsResponse is the response type for the Query/Authorizations RPC method.
+message QueryGrantsResponse {
+  // authorizations is a list of grants granted for grantee by granter.
+  repeated cosmos.authz.v1beta1.Grant grants = 1;
+  // pagination defines an pagination for the response.
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/tx.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/tx.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+package cosmos.authz.v1beta1;
+
+import "cosmos_proto/cosmos.proto";
+import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+import "cosmos/base/abci/v1beta1/abci.proto";
+import "cosmos/authz/v1beta1/authz.proto";
+
+option go_package                      = "github.com/cosmos/cosmos-sdk/x/authz";
+option (gogoproto.goproto_getters_all) = false;
+
+// Msg defines the authz Msg service.
+service Msg {
+  // Grant grants the provided authorization to the grantee on the granter's
+  // account with the provided expiration time. If there is already a grant
+  // for the given (granter, grantee, Authorization) triple, then the grant
+  // will be overwritten.
+  rpc Grant(MsgGrant) returns (MsgGrantResponse);
+
+  // Exec attempts to execute the provided messages using
+  // authorizations granted to the grantee. Each message should have only
+  // one signer corresponding to the granter of the authorization.
+  rpc Exec(MsgExec) returns (MsgExecResponse);
+
+  // Revoke revokes any authorization corresponding to the provided method name on the
+  // granter's account that has been granted to the grantee.
+  rpc Revoke(MsgRevoke) returns (MsgRevokeResponse);
+}
+
+// MsgGrant is a request type for Grant method. It declares authorization to the grantee
+// on behalf of the granter with the provided expiration time.
+message MsgGrant {
+  string granter = 1;
+  string grantee = 2;
+
+  cosmos.authz.v1beta1.Grant grant = 3 [(gogoproto.nullable) = false];
+}
+
+// MsgExecResponse defines the Msg/MsgExecResponse response type.
+message MsgExecResponse {
+  repeated bytes results = 1;
+}
+
+// MsgExec attempts to execute the provided messages using
+// authorizations granted to the grantee. Each message should have only
+// one signer corresponding to the granter of the authorization.
+message MsgExec {
+  string grantee = 1;
+  // Authorization Msg requests to execute. Each msg must implement Authorization interface
+  // The x/authz will try to find a grant matching (msg.signers[0], grantee, MsgTypeURL(msg))
+  // triple and validate it.
+  repeated google.protobuf.Any msgs = 2 [(cosmos_proto.accepts_interface) = "sdk.Msg, authz.Authorization"];
+}
+
+// MsgGrantResponse defines the Msg/MsgGrant response type.
+message MsgGrantResponse {}
+
+// MsgRevoke revokes any authorization with the provided sdk.Msg type on the
+// granter's account with that has been granted to the grantee.
+message MsgRevoke {
+  string granter      = 1;
+  string grantee      = 2;
+  string msg_type_url = 3;
+}
+
+// MsgRevokeResponse defines the Msg/MsgRevokeResponse response type.
+message MsgRevokeResponse {}

--- a/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/authz.proto
+++ b/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/authz.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+package cosmos.bank.v1beta1;
+
+import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
+import "cosmos/base/v1beta1/coin.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/bank/types";
+
+// SendAuthorization allows the grantee to spend up to spend_limit coins from
+// the granter's account.
+message SendAuthorization {
+  option (cosmos_proto.implements_interface) = "Authorization";
+
+  repeated cosmos.base.v1beta1.Coin spend_limit = 1
+      [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+}

--- a/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/bank.proto
+++ b/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/bank.proto
@@ -45,12 +45,14 @@ message Output {
 
 // Supply represents a struct that passively keeps track of the total supply
 // amounts in the network.
+// This message is deprecated now that supply is indexed by denom.
 message Supply {
-  option (gogoproto.equal)            = true;
-  option (gogoproto.goproto_getters)  = false;
-  option (gogoproto.goproto_stringer) = false;
+  option deprecated = true;
 
-  option (cosmos_proto.implements_interface) = "*github.com/cosmos/cosmos-sdk/x/bank/exported.SupplyI";
+  option (gogoproto.equal)           = true;
+  option (gogoproto.goproto_getters) = false;
+
+  option (cosmos_proto.implements_interface) = "*github.com/cosmos/cosmos-sdk/x/bank/legacy/v040.SupplyI";
 
   repeated cosmos.base.v1beta1.Coin total = 1
       [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
@@ -82,4 +84,9 @@ message Metadata {
   // display indicates the suggested denom that should be
   // displayed in clients.
   string display = 4;
+  // name defines the name of the token (eg: Cosmos Atom)
+  string name = 5;
+  // symbol is the token symbol usually shown on exchanges (eg: ATOM). This can
+  // be the same as the display.
+  string symbol = 6;
 }

--- a/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/genesis.proto
+++ b/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/genesis.proto
@@ -15,7 +15,8 @@ message GenesisState {
   // balances is an array containing the balances of all the accounts.
   repeated Balance balances = 2 [(gogoproto.nullable) = false];
 
-  // supply represents the total supply.
+  // supply represents the total supply. If it is left empty, then supply will be calculated based on the provided
+  // balances. Otherwise, it will be used to validate that the sum of the balances equals this amount.
   repeated cosmos.base.v1beta1.Coin supply = 3
       [(gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.nullable) = false];
 

--- a/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/query.proto
@@ -90,7 +90,13 @@ message QueryAllBalancesResponse {
 
 // QueryTotalSupplyRequest is the request type for the Query/TotalSupply RPC
 // method.
-message QueryTotalSupplyRequest {}
+message QueryTotalSupplyRequest {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
 
 // QueryTotalSupplyResponse is the response type for the Query/TotalSupply RPC
 // method
@@ -98,6 +104,9 @@ message QueryTotalSupplyResponse {
   // supply is the supply of the coins
   repeated cosmos.base.v1beta1.Coin supply = 1
       [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+
+  // pagination defines the pagination in the response.
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
 // QuerySupplyOfRequest is the request type for the Query/SupplyOf RPC method.

--- a/pb-proto-java/src/main/proto/cosmos/base/query/v1beta1/pagination.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/query/v1beta1/pagination.proto
@@ -30,6 +30,9 @@ message PageRequest {
   // count_total is only respected when offset is used. It is ignored when key
   // is set.
   bool count_total = 4;
+
+  // reverse is set to true if results are to be returned in the descending order.
+  bool reverse = 5;
 }
 
 // PageResponse is to be embedded in gRPC response messages where the

--- a/pb-proto-java/src/main/proto/cosmos/base/reflection/v2alpha1/reflection.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/reflection/v2alpha1/reflection.proto
@@ -1,0 +1,217 @@
+syntax = "proto3";
+package cosmos.base.reflection.v2alpha1;
+
+import "google/api/annotations.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/server/grpc/reflection/v2alpha1";
+
+// AppDescriptor describes a cosmos-sdk based application
+message AppDescriptor {
+  // AuthnDescriptor provides information on how to authenticate transactions on the application
+  // NOTE: experimental and subject to change in future releases.
+  AuthnDescriptor authn = 1;
+  // chain provides the chain descriptor
+  ChainDescriptor chain = 2;
+  // codec provides metadata information regarding codec related types
+  CodecDescriptor codec = 3;
+  // configuration provides metadata information regarding the sdk.Config type
+  ConfigurationDescriptor configuration = 4;
+  // query_services provides metadata information regarding the available queriable endpoints
+  QueryServicesDescriptor query_services = 5;
+  // tx provides metadata information regarding how to send transactions to the given application
+  TxDescriptor tx = 6;
+}
+
+// TxDescriptor describes the accepted transaction type
+message TxDescriptor {
+  // fullname is the protobuf fullname of the raw transaction type (for instance the tx.Tx type)
+  // it is not meant to support polymorphism of transaction types, it is supposed to be used by
+  // reflection clients to understand if they can handle a specific transaction type in an application.
+  string fullname = 1;
+  // msgs lists the accepted application messages (sdk.Msg)
+  repeated MsgDescriptor msgs = 2;
+}
+
+// AuthnDescriptor provides information on how to sign transactions without relying
+// on the online RPCs GetTxMetadata and CombineUnsignedTxAndSignatures
+message AuthnDescriptor {
+  // sign_modes defines the supported signature algorithm
+  repeated SigningModeDescriptor sign_modes = 1;
+}
+
+// SigningModeDescriptor provides information on a signing flow of the application
+// NOTE(fdymylja): here we could go as far as providing an entire flow on how
+// to sign a message given a SigningModeDescriptor, but it's better to think about
+// this another time
+message SigningModeDescriptor {
+  // name defines the unique name of the signing mode
+  string name = 1;
+  // number is the unique int32 identifier for the sign_mode enum
+  int32 number = 2;
+  // authn_info_provider_method_fullname defines the fullname of the method to call to get
+  // the metadata required to authenticate using the provided sign_modes
+  string authn_info_provider_method_fullname = 3;
+}
+
+// ChainDescriptor describes chain information of the application
+message ChainDescriptor {
+  // id is the chain id
+  string id = 1;
+}
+
+// CodecDescriptor describes the registered interfaces and provides metadata information on the types
+message CodecDescriptor {
+  // interfaces is a list of the registerted interfaces descriptors
+  repeated InterfaceDescriptor interfaces = 1;
+}
+
+// InterfaceDescriptor describes the implementation of an interface
+message InterfaceDescriptor {
+  // fullname is the name of the interface
+  string fullname = 1;
+  // interface_accepting_messages contains information regarding the proto messages which contain the interface as
+  // google.protobuf.Any field
+  repeated InterfaceAcceptingMessageDescriptor interface_accepting_messages = 2;
+  // interface_implementers is a list of the descriptors of the interface implementers
+  repeated InterfaceImplementerDescriptor interface_implementers = 3;
+}
+
+// InterfaceImplementerDescriptor describes an interface implementer
+message InterfaceImplementerDescriptor {
+  // fullname is the protobuf queryable name of the interface implementer
+  string fullname = 1;
+  // type_url defines the type URL used when marshalling the type as any
+  // this is required so we can provide type safe google.protobuf.Any marshalling and
+  // unmarshalling, making sure that we don't accept just 'any' type
+  // in our interface fields
+  string type_url = 2;
+}
+
+// InterfaceAcceptingMessageDescriptor describes a protobuf message which contains
+// an interface represented as a google.protobuf.Any
+message InterfaceAcceptingMessageDescriptor {
+  // fullname is the protobuf fullname of the type containing the interface
+  string fullname = 1;
+  // field_descriptor_names is a list of the protobuf name (not fullname) of the field
+  // which contains the interface as google.protobuf.Any (the interface is the same, but
+  // it can be in multiple fields of the same proto message)
+  repeated string field_descriptor_names = 2;
+}
+
+// ConfigurationDescriptor contains metadata information on the sdk.Config
+message ConfigurationDescriptor {
+  // bech32_account_address_prefix is the account address prefix
+  string bech32_account_address_prefix = 1;
+}
+
+// MsgDescriptor describes a cosmos-sdk message that can be delivered with a transaction
+message MsgDescriptor {
+  // msg_type_url contains the TypeURL of a sdk.Msg.
+  string msg_type_url = 1;
+}
+
+// ReflectionService defines a service for application reflection.
+service ReflectionService {
+  // GetAuthnDescriptor returns information on how to authenticate transactions in the application
+  // NOTE: this RPC is still experimental and might be subject to breaking changes or removal in
+  // future releases of the cosmos-sdk.
+  rpc GetAuthnDescriptor(GetAuthnDescriptorRequest) returns (GetAuthnDescriptorResponse) {
+    option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/authn";
+  }
+  // GetChainDescriptor returns the description of the chain
+  rpc GetChainDescriptor(GetChainDescriptorRequest) returns (GetChainDescriptorResponse) {
+    option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/chain";
+  };
+  // GetCodecDescriptor returns the descriptor of the codec of the application
+  rpc GetCodecDescriptor(GetCodecDescriptorRequest) returns (GetCodecDescriptorResponse) {
+    option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/codec";
+  }
+  // GetConfigurationDescriptor returns the descriptor for the sdk.Config of the application
+  rpc GetConfigurationDescriptor(GetConfigurationDescriptorRequest) returns (GetConfigurationDescriptorResponse) {
+    option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/configuration";
+  }
+  // GetQueryServicesDescriptor returns the available gRPC queryable services of the application
+  rpc GetQueryServicesDescriptor(GetQueryServicesDescriptorRequest) returns (GetQueryServicesDescriptorResponse) {
+    option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/query_services";
+  }
+  // GetTxDescriptor returns information on the used transaction object and available msgs that can be used
+  rpc GetTxDescriptor(GetTxDescriptorRequest) returns (GetTxDescriptorResponse) {
+    option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/tx_descriptor";
+  }
+}
+
+// GetAuthnDescriptorRequest is the request used for the GetAuthnDescriptor RPC
+message GetAuthnDescriptorRequest {}
+// GetAuthnDescriptorResponse is the response returned by the GetAuthnDescriptor RPC
+message GetAuthnDescriptorResponse {
+  // authn describes how to authenticate to the application when sending transactions
+  AuthnDescriptor authn = 1;
+}
+
+// GetChainDescriptorRequest is the request used for the GetChainDescriptor RPC
+message GetChainDescriptorRequest {}
+// GetChainDescriptorResponse is the response returned by the GetChainDescriptor RPC
+message GetChainDescriptorResponse {
+  // chain describes application chain information
+  ChainDescriptor chain = 1;
+}
+
+// GetCodecDescriptorRequest is the request used for the GetCodecDescriptor RPC
+message GetCodecDescriptorRequest {}
+// GetCodecDescriptorResponse is the response returned by the GetCodecDescriptor RPC
+message GetCodecDescriptorResponse {
+  // codec describes the application codec such as registered interfaces and implementations
+  CodecDescriptor codec = 1;
+}
+
+// GetConfigurationDescriptorRequest is the request used for the GetConfigurationDescriptor RPC
+message GetConfigurationDescriptorRequest {}
+// GetConfigurationDescriptorResponse is the response returned by the GetConfigurationDescriptor RPC
+message GetConfigurationDescriptorResponse {
+  // config describes the application's sdk.Config
+  ConfigurationDescriptor config = 1;
+}
+
+// GetQueryServicesDescriptorRequest is the request used for the GetQueryServicesDescriptor RPC
+message GetQueryServicesDescriptorRequest {}
+// GetQueryServicesDescriptorResponse is the response returned by the GetQueryServicesDescriptor RPC
+message GetQueryServicesDescriptorResponse {
+  // queries provides information on the available queryable services
+  QueryServicesDescriptor queries = 1;
+}
+
+// GetTxDescriptorRequest is the request used for the GetTxDescriptor RPC
+message GetTxDescriptorRequest {}
+// GetTxDescriptorResponse is the response returned by the GetTxDescriptor RPC
+message GetTxDescriptorResponse {
+  // tx provides information on msgs that can be forwarded to the application
+  // alongside the accepted transaction protobuf type
+  TxDescriptor tx = 1;
+}
+
+// QueryServicesDescriptor contains the list of cosmos-sdk queriable services
+message QueryServicesDescriptor {
+  // query_services is a list of cosmos-sdk QueryServiceDescriptor
+  repeated QueryServiceDescriptor query_services = 1;
+}
+
+// QueryServiceDescriptor describes a cosmos-sdk queryable service
+message QueryServiceDescriptor {
+  // fullname is the protobuf fullname of the service descriptor
+  string fullname = 1;
+  // is_module describes if this service is actually exposed by an application's module
+  bool is_module = 2;
+  // methods provides a list of query service methods
+  repeated QueryMethodDescriptor methods = 3;
+}
+
+// QueryMethodDescriptor describes a queryable method of a query service
+// no other info is provided beside method name and tendermint queryable path
+// because it would be redundant with the grpc reflection service
+message QueryMethodDescriptor {
+  // name is the protobuf name (not fullname) of the method
+  string name = 1;
+  // full_query_path is the path that can be used to query
+  // this method via tendermint abci.Query
+  string full_query_path = 2;
+}

--- a/pb-proto-java/src/main/proto/cosmos/base/store/v1beta1/listening.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/store/v1beta1/listening.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package cosmos.base.store.v1beta1;
+
+option go_package = "github.com/cosmos/cosmos-sdk/store/types";
+
+// StoreKVPair is a KVStore KVPair used for listening to state changes (Sets and Deletes)
+// It optionally includes the StoreKey for the originating KVStore and a Boolean flag to distinguish between Sets and
+// Deletes
+message StoreKVPair {
+  string store_key = 1; // the store key for the KVStore this pair originates from
+  bool delete      = 2; // true indicates a delete operation, false indicates a set operation
+  bytes key        = 3;
+  bytes value      = 4;
+}

--- a/pb-proto-java/src/main/proto/cosmos/crypto/ed25519/keys.proto
+++ b/pb-proto-java/src/main/proto/cosmos/crypto/ed25519/keys.proto
@@ -5,18 +5,19 @@ import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519";
 
-// PubKey defines a ed25519 public key
-// Key is the compressed form of the pubkey. The first byte depends is a 0x02 byte
-// if the y-coordinate is the lexicographically largest of the two associated with
-// the x-coordinate. Otherwise the first byte is a 0x03.
-// This prefix is followed with the x-coordinate.
+// PubKey is an ed25519 public key for handling Tendermint keys in SDK.
+// It's needed for Any serialization and SDK compatibility.
+// It must not be used in a non Tendermint key context because it doesn't implement
+// ADR-28. Nevertheless, you will like to use ed25519 in app user level
+// then you must create a new proto message and follow ADR-28 for Address construction.
 message PubKey {
   option (gogoproto.goproto_stringer) = false;
 
   bytes key = 1 [(gogoproto.casttype) = "crypto/ed25519.PublicKey"];
 }
 
-// PrivKey defines a ed25519 private key.
+// Deprecated: PrivKey defines a ed25519 private key.
+// NOTE: ed25519 keys must not be used in SDK apps except in a tendermint validator context.
 message PrivKey {
   bytes key = 1 [(gogoproto.casttype) = "crypto/ed25519.PrivateKey"];
 }

--- a/pb-proto-java/src/main/proto/cosmos/crypto/secp256r1/keys.proto
+++ b/pb-proto-java/src/main/proto/cosmos/crypto/secp256r1/keys.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+package cosmos.crypto.secp256r1;
+
+import "gogoproto/gogo.proto";
+
+option go_package                       = "github.com/cosmos/cosmos-sdk/crypto/keys/secp256r1";
+option (gogoproto.messagename_all)      = true;
+option (gogoproto.goproto_stringer_all) = false;
+option (gogoproto.goproto_getters_all)  = false;
+
+// PubKey defines a secp256r1 ECDSA public key.
+message PubKey {
+  // Point on secp256r1 curve in a compressed representation as specified in section
+  // 4.3.6 of ANSI X9.62: https://webstore.ansi.org/standards/ascx9/ansix9621998
+  bytes key = 1 [(gogoproto.customtype) = "ecdsaPK"];
+}
+
+// PrivKey defines a secp256r1 ECDSA private key.
+message PrivKey {
+  // secret number serialized using big-endian encoding
+  bytes secret = 1 [(gogoproto.customtype) = "ecdsaSK"];
+}

--- a/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/feegrant.proto
+++ b/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/feegrant.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+package cosmos.feegrant.v1beta1;
+
+import "gogoproto/gogo.proto";
+import "google/protobuf/any.proto";
+import "cosmos_proto/cosmos.proto";
+import "cosmos/base/v1beta1/coin.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/feegrant";
+
+// BasicAllowance implements Allowance with a one-time grant of tokens
+// that optionally expires. The grantee can use up to SpendLimit to cover fees.
+message BasicAllowance {
+  option (cosmos_proto.implements_interface) = "FeeAllowanceI";
+
+  // spend_limit specifies the maximum amount of tokens that can be spent
+  // by this allowance and will be updated as tokens are spent. If it is
+  // empty, there is no spend limit and any amount of coins can be spent.
+  repeated cosmos.base.v1beta1.Coin spend_limit = 1
+      [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+
+  // expiration specifies an optional time when this allowance expires
+  google.protobuf.Timestamp expiration = 2 [(gogoproto.stdtime) = true];
+}
+
+// PeriodicAllowance extends Allowance to allow for both a maximum cap,
+// as well as a limit per time period.
+message PeriodicAllowance {
+  option (cosmos_proto.implements_interface) = "FeeAllowanceI";
+
+  // basic specifies a struct of `BasicAllowance`
+  BasicAllowance basic = 1 [(gogoproto.nullable) = false];
+
+  // period specifies the time duration in which period_spend_limit coins can
+  // be spent before that allowance is reset
+  google.protobuf.Duration period = 2 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+
+  // period_spend_limit specifies the maximum number of coins that can be spent
+  // in the period
+  repeated cosmos.base.v1beta1.Coin period_spend_limit = 3
+      [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+
+  // period_can_spend is the number of coins left to be spent before the period_reset time
+  repeated cosmos.base.v1beta1.Coin period_can_spend = 4
+      [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+
+  // period_reset is the time at which this period resets and a new one begins,
+  // it is calculated from the start time of the first transaction after the
+  // last period ended
+  google.protobuf.Timestamp period_reset = 5 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+}
+
+// AllowedMsgAllowance creates allowance only for specified message types.
+message AllowedMsgAllowance {
+  option (gogoproto.goproto_getters)         = false;
+  option (cosmos_proto.implements_interface) = "FeeAllowanceI";
+
+  // allowance can be any of basic and filtered fee allowance.
+  google.protobuf.Any allowance = 1 [(cosmos_proto.accepts_interface) = "FeeAllowanceI"];
+
+  // allowed_messages are the messages for which the grantee has the access.
+  repeated string allowed_messages = 2;
+}
+
+// Grant is stored in the KVStore to record a grant with full context
+message Grant {
+  // granter is the address of the user granting an allowance of their funds.
+  string granter = 1;
+
+  // grantee is the address of the user being granted an allowance of another user's funds.
+  string grantee = 2;
+
+  // allowance can be any of basic and filtered fee allowance.
+  google.protobuf.Any allowance = 3 [(cosmos_proto.accepts_interface) = "FeeAllowanceI"];
+}

--- a/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/genesis.proto
+++ b/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/genesis.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package cosmos.feegrant.v1beta1;
+
+import "gogoproto/gogo.proto";
+import "cosmos/feegrant/v1beta1/feegrant.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/feegrant";
+
+// GenesisState contains a set of fee allowances, persisted from the store
+message GenesisState {
+  repeated Grant allowances = 1 [(gogoproto.nullable) = false];
+}

--- a/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/query.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+package cosmos.feegrant.v1beta1;
+
+import "cosmos/feegrant/v1beta1/feegrant.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "google/api/annotations.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/feegrant";
+
+// Query defines the gRPC querier service.
+service Query {
+
+  // Allowance returns fee granted to the grantee by the granter.
+  rpc Allowance(QueryAllowanceRequest) returns (QueryAllowanceResponse) {
+    option (google.api.http).get = "/cosmos/feegrant/v1beta1/allowance/{granter}/{grantee}";
+  }
+
+  // Allowances returns all the grants for address.
+  rpc Allowances(QueryAllowancesRequest) returns (QueryAllowancesResponse) {
+    option (google.api.http).get = "/cosmos/feegrant/v1beta1/allowances/{grantee}";
+  }
+}
+
+// QueryAllowanceRequest is the request type for the Query/Allowance RPC method.
+message QueryAllowanceRequest {
+  // granter is the address of the user granting an allowance of their funds.
+  string granter = 1;
+
+  // grantee is the address of the user being granted an allowance of another user's funds.
+  string grantee = 2;
+}
+
+// QueryAllowanceResponse is the response type for the Query/Allowance RPC method.
+message QueryAllowanceResponse {
+  // allowance is a allowance granted for grantee by granter.
+  cosmos.feegrant.v1beta1.Grant allowance = 1;
+}
+
+// QueryAllowancesRequest is the request type for the Query/Allowances RPC method.
+message QueryAllowancesRequest {
+  string grantee = 1;
+
+  // pagination defines an pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 2;
+}
+
+// QueryAllowancesResponse is the response type for the Query/Allowances RPC method.
+message QueryAllowancesResponse {
+  // allowances are allowance's granted for grantee by granter.
+  repeated cosmos.feegrant.v1beta1.Grant allowances = 1;
+
+  // pagination defines an pagination for the response.
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}

--- a/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/tx.proto
+++ b/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/tx.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+package cosmos.feegrant.v1beta1;
+
+import "gogoproto/gogo.proto";
+import "google/protobuf/any.proto";
+import "cosmos_proto/cosmos.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/feegrant";
+
+// Msg defines the feegrant msg service.
+service Msg {
+
+  // GrantAllowance grants fee allowance to the grantee on the granter's
+  // account with the provided expiration time.
+  rpc GrantAllowance(MsgGrantAllowance) returns (MsgGrantAllowanceResponse);
+
+  // RevokeAllowance revokes any fee allowance of granter's account that
+  // has been granted to the grantee.
+  rpc RevokeAllowance(MsgRevokeAllowance) returns (MsgRevokeAllowanceResponse);
+}
+
+// MsgGrantAllowance adds permission for Grantee to spend up to Allowance
+// of fees from the account of Granter.
+message MsgGrantAllowance {
+  // granter is the address of the user granting an allowance of their funds.
+  string granter = 1;
+
+  // grantee is the address of the user being granted an allowance of another user's funds.
+  string grantee = 2;
+
+  // allowance can be any of basic and filtered fee allowance.
+  google.protobuf.Any allowance = 3 [(cosmos_proto.accepts_interface) = "FeeAllowanceI"];
+}
+
+// MsgGrantAllowanceResponse defines the Msg/GrantAllowanceResponse response type.
+message MsgGrantAllowanceResponse {}
+
+// MsgRevokeAllowance removes any existing Allowance from Granter to Grantee.
+message MsgRevokeAllowance {
+  // granter is the address of the user granting an allowance of their funds.
+  string granter = 1;
+
+  // grantee is the address of the user being granted an allowance of another user's funds.
+  string grantee = 2;
+}
+
+// MsgRevokeAllowanceResponse defines the Msg/RevokeAllowanceResponse response type.
+message MsgRevokeAllowanceResponse {}

--- a/pb-proto-java/src/main/proto/cosmos/gov/v1beta1/gov.proto
+++ b/pb-proto-java/src/main/proto/cosmos/gov/v1beta1/gov.proto
@@ -29,6 +29,16 @@ enum VoteOption {
   VOTE_OPTION_NO_WITH_VETO = 4 [(gogoproto.enumvalue_customname) = "OptionNoWithVeto"];
 }
 
+// WeightedVoteOption defines a unit of vote for vote split.
+message WeightedVoteOption {
+  VoteOption option = 1;
+  string     weight = 2 [
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable)   = false,
+    (gogoproto.moretags)   = "yaml:\"weight\""
+  ];
+}
+
 // TextProposal defines a standard text proposal whose changes need to be
 // manually updated in case of approval.
 message TextProposal {
@@ -119,9 +129,13 @@ message Vote {
   option (gogoproto.goproto_stringer) = false;
   option (gogoproto.equal)            = false;
 
-  uint64     proposal_id = 1 [(gogoproto.moretags) = "yaml:\"proposal_id\""];
-  string     voter       = 2;
-  VoteOption option      = 3;
+  uint64 proposal_id = 1 [(gogoproto.moretags) = "yaml:\"proposal_id\""];
+  string voter       = 2;
+  // Deprecated: Prefer to use `options` instead. This field is set in queries
+  // if and only if `len(options) == 1` and that option has weight 1. In all
+  // other cases, this field will default to VOTE_OPTION_UNSPECIFIED.
+  VoteOption                  option  = 3 [deprecated = true];
+  repeated WeightedVoteOption options = 4 [(gogoproto.nullable) = false];
 }
 
 // DepositParams defines the params for deposits on governance proposals.

--- a/pb-proto-java/src/main/proto/cosmos/gov/v1beta1/tx.proto
+++ b/pb-proto-java/src/main/proto/cosmos/gov/v1beta1/tx.proto
@@ -17,6 +17,9 @@ service Msg {
   // Vote defines a method to add a vote on a specific proposal.
   rpc Vote(MsgVote) returns (MsgVoteResponse);
 
+  // VoteWeighted defines a method to add a weighted vote on a specific proposal.
+  rpc VoteWeighted(MsgVoteWeighted) returns (MsgVoteWeightedResponse);
+
   // Deposit defines a method to add deposit on a specific proposal.
   rpc Deposit(MsgDeposit) returns (MsgDepositResponse);
 }
@@ -57,6 +60,21 @@ message MsgVote {
 
 // MsgVoteResponse defines the Msg/Vote response type.
 message MsgVoteResponse {}
+
+// MsgVoteWeighted defines a message to cast a vote.
+message MsgVoteWeighted {
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_stringer) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
+
+  uint64                      proposal_id = 1 [(gogoproto.moretags) = "yaml:\"proposal_id\""];
+  string                      voter       = 2;
+  repeated WeightedVoteOption options     = 3 [(gogoproto.nullable) = false];
+}
+
+// MsgVoteWeightedResponse defines the Msg/VoteWeighted response type.
+message MsgVoteWeightedResponse {}
 
 // MsgDeposit defines a message to submit a deposit to an existing proposal.
 message MsgDeposit {

--- a/pb-proto-java/src/main/proto/cosmos/slashing/v1beta1/genesis.proto
+++ b/pb-proto-java/src/main/proto/cosmos/slashing/v1beta1/genesis.proto
@@ -16,7 +16,7 @@ message GenesisState {
   repeated SigningInfo signing_infos = 2
       [(gogoproto.moretags) = "yaml:\"signing_infos\"", (gogoproto.nullable) = false];
 
-  // signing_infos represents a map between validator addresses and their
+  // missed_blocks represents a map between validator addresses and their
   // missed blocks.
   repeated ValidatorMissedBlocks missed_blocks = 3
       [(gogoproto.moretags) = "yaml:\"missed_blocks\"", (gogoproto.nullable) = false];

--- a/pb-proto-java/src/main/proto/cosmos/slashing/v1beta1/slashing.proto
+++ b/pb-proto-java/src/main/proto/cosmos/slashing/v1beta1/slashing.proto
@@ -15,17 +15,20 @@ message ValidatorSigningInfo {
   option (gogoproto.goproto_stringer) = false;
 
   string address = 1;
-  // height at which validator was first a candidate OR was unjailed
+  // Height at which validator was first a candidate OR was unjailed
   int64 start_height = 2 [(gogoproto.moretags) = "yaml:\"start_height\""];
-  // index offset into signed block bit array
+  // Index which is incremented each time the validator was a bonded
+  // in a block and may have signed a precommit or not. This in conjunction with the
+  // `SignedBlocksWindow` param determines the index in the `MissedBlocksBitArray`.
   int64 index_offset = 3 [(gogoproto.moretags) = "yaml:\"index_offset\""];
-  // timestamp validator cannot be unjailed until
+  // Timestamp until which the validator is jailed due to liveness downtime.
   google.protobuf.Timestamp jailed_until = 4
       [(gogoproto.moretags) = "yaml:\"jailed_until\"", (gogoproto.stdtime) = true, (gogoproto.nullable) = false];
-  // whether or not a validator has been tombstoned (killed out of validator
-  // set)
+  // Whether or not a validator has been tombstoned (killed out of validator set). It is set
+  // once the validator commits an equivocation or for any other configured misbehiavor.
   bool tombstoned = 5;
-  // missed blocks counter (to avoid scanning the array every time)
+  // A counter kept to avoid unnecessary array reads.
+  // Note that `Sum(MissedBlocksBitArray)` always equals `MissedBlocksCounter`.
   int64 missed_blocks_counter = 6 [(gogoproto.moretags) = "yaml:\"missed_blocks_counter\""];
 }
 

--- a/pb-proto-java/src/main/proto/cosmos/staking/v1beta1/authz.proto
+++ b/pb-proto-java/src/main/proto/cosmos/staking/v1beta1/authz.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+package cosmos.staking.v1beta1;
+
+import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
+import "cosmos/base/v1beta1/coin.proto";
+
+option go_package = "github.com/cosmos/cosmos-sdk/x/staking/types";
+
+// StakeAuthorization defines authorization for delegate/undelegate/redelegate.
+message StakeAuthorization {
+  option (cosmos_proto.implements_interface) = "Authorization";
+
+  // max_tokens specifies the maximum amount of tokens can be delegate to a validator. If it is
+  // empty, there is no spend limit and any amount of coins can be delegated.
+  cosmos.base.v1beta1.Coin max_tokens = 1 [(gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coin"];
+  // validators is the oneof that represents either allow_list or deny_list
+  oneof validators {
+    // allow_list specifies list of validator addresses to whom grantee can delegate tokens on behalf of granter's
+    // account.
+    Validators allow_list = 2;
+    // deny_list specifies list of validator addresses to whom grantee can not delegate tokens.
+    Validators deny_list = 3;
+  }
+  // Validators defines list of validator addresses.
+  message Validators {
+    repeated string address = 1;
+  }
+  // authorization_type defines one of AuthorizationType.
+  AuthorizationType authorization_type = 4;
+}
+
+// AuthorizationType defines the type of staking module authorization type
+enum AuthorizationType {
+  // AUTHORIZATION_TYPE_UNSPECIFIED specifies an unknown authorization type
+  AUTHORIZATION_TYPE_UNSPECIFIED = 0;
+  // AUTHORIZATION_TYPE_DELEGATE defines an authorization type for Msg/Delegate
+  AUTHORIZATION_TYPE_DELEGATE = 1;
+  // AUTHORIZATION_TYPE_UNDELEGATE defines an authorization type for Msg/Undelegate
+  AUTHORIZATION_TYPE_UNDELEGATE = 2;
+  // AUTHORIZATION_TYPE_REDELEGATE defines an authorization type for Msg/BeginRedelegate
+  AUTHORIZATION_TYPE_REDELEGATE = 3;
+}

--- a/pb-proto-java/src/main/proto/cosmos/staking/v1beta1/staking.proto
+++ b/pb-proto-java/src/main/proto/cosmos/staking/v1beta1/staking.proto
@@ -28,7 +28,7 @@ message CommissionRates {
   option (gogoproto.goproto_stringer) = false;
 
   // rate is the commission rate charged to delegators, as a fraction.
-  string rate     = 1 [(gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec", (gogoproto.nullable) = false];
+  string rate = 1 [(gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec", (gogoproto.nullable) = false];
   // max_rate defines the maximum commission rate which validator can ever charge, as a fraction.
   string max_rate = 2 [
     (gogoproto.moretags)   = "yaml:\"max_rate\"",
@@ -49,9 +49,9 @@ message Commission {
   option (gogoproto.goproto_stringer) = false;
 
   // commission_rates defines the initial commission rates to be used for creating a validator.
-  CommissionRates           commission_rates = 1 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
+  CommissionRates commission_rates = 1 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
   // update_time is the last time the commission rate was changed.
-  google.protobuf.Timestamp update_time      = 2
+  google.protobuf.Timestamp update_time = 2
       [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.moretags) = "yaml:\"update_time\""];
 }
 
@@ -61,15 +61,15 @@ message Description {
   option (gogoproto.goproto_stringer) = false;
 
   // moniker defines a human-readable name for the validator.
-  string moniker          = 1;
+  string moniker = 1;
   // identity defines an optional identity signature (ex. UPort or Keybase).
-  string identity         = 2;
+  string identity = 2;
   // website defines an optional website link.
-  string website          = 3;
+  string website = 3;
   // security_contact defines an optional email for security contact.
   string security_contact = 4 [(gogoproto.moretags) = "yaml:\"security_contact\""];
   // details define other optional details.
-  string details          = 5;
+  string details = 5;
 }
 
 // Validator defines a validator, together with the total amount of the
@@ -86,12 +86,12 @@ message Validator {
   option (gogoproto.goproto_getters)  = false;
 
   // operator_address defines the address of the validator's operator; bech encoded in JSON.
-  string              operator_address = 1 [(gogoproto.moretags) = "yaml:\"operator_address\""];
+  string operator_address = 1 [(gogoproto.moretags) = "yaml:\"operator_address\""];
   // consensus_pubkey is the consensus public key of the validator, as a Protobuf Any.
   google.protobuf.Any consensus_pubkey = 2
       [(cosmos_proto.accepts_interface) = "cosmos.crypto.PubKey", (gogoproto.moretags) = "yaml:\"consensus_pubkey\""];
   // jailed defined whether the validator has been jailed from bonded status or not.
-  bool       jailed = 3;
+  bool jailed = 3;
   // status is the validator status (bonded/unbonding/unbonded).
   BondStatus status = 4;
   // tokens define the delegated tokens (incl. self-delegation).
@@ -103,16 +103,16 @@ message Validator {
     (gogoproto.nullable)   = false
   ];
   // description defines the description terms for the validator.
-  Description               description      = 7 [(gogoproto.nullable) = false];
+  Description description = 7 [(gogoproto.nullable) = false];
   // unbonding_height defines, if unbonding, the height at which this validator has begun unbonding.
-  int64                     unbonding_height = 8 [(gogoproto.moretags) = "yaml:\"unbonding_height\""];
+  int64 unbonding_height = 8 [(gogoproto.moretags) = "yaml:\"unbonding_height\""];
   // unbonding_time defines, if unbonding, the min time for the validator to complete unbonding.
-  google.protobuf.Timestamp unbonding_time   = 9
+  google.protobuf.Timestamp unbonding_time = 9
       [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.moretags) = "yaml:\"unbonding_time\""];
   // commission defines the commission parameters.
-  Commission commission          = 10 [(gogoproto.nullable) = false];
+  Commission commission = 10 [(gogoproto.nullable) = false];
   // min_self_delegation is the validator's self declared minimum self delegation.
-  string     min_self_delegation = 11 [
+  string min_self_delegation = 11 [
     (gogoproto.moretags)   = "yaml:\"min_self_delegation\"",
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
     (gogoproto.nullable)   = false
@@ -201,9 +201,9 @@ message UnbondingDelegation {
   option (gogoproto.goproto_stringer) = false;
 
   // delegator_address is the bech32-encoded address of the delegator.
-  string                            delegator_address = 1 [(gogoproto.moretags) = "yaml:\"delegator_address\""];
+  string delegator_address = 1 [(gogoproto.moretags) = "yaml:\"delegator_address\""];
   // validator_address is the bech32-encoded address of the validator.
-  string                            validator_address = 2 [(gogoproto.moretags) = "yaml:\"validator_address\""];
+  string validator_address = 2 [(gogoproto.moretags) = "yaml:\"validator_address\""];
   // entries are the unbonding delegation entries.
   repeated UnbondingDelegationEntry entries = 3 [(gogoproto.nullable) = false]; // unbonding delegation entries
 }
@@ -214,7 +214,7 @@ message UnbondingDelegationEntry {
   option (gogoproto.goproto_stringer) = false;
 
   // creation_height is the height which the unbonding took place.
-  int64                     creation_height = 1 [(gogoproto.moretags) = "yaml:\"creation_height\""];
+  int64 creation_height = 1 [(gogoproto.moretags) = "yaml:\"creation_height\""];
   // completion_time is the unix time for unbonding completion.
   google.protobuf.Timestamp completion_time = 2
       [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.moretags) = "yaml:\"completion_time\""];
@@ -234,7 +234,7 @@ message RedelegationEntry {
   option (gogoproto.goproto_stringer) = false;
 
   // creation_height  defines the height which the redelegation took place.
-  int64                     creation_height = 1 [(gogoproto.moretags) = "yaml:\"creation_height\""];
+  int64 creation_height = 1 [(gogoproto.moretags) = "yaml:\"creation_height\""];
   // completion_time defines the unix time for redelegation completion.
   google.protobuf.Timestamp completion_time = 2
       [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.moretags) = "yaml:\"completion_time\""];
@@ -257,13 +257,13 @@ message Redelegation {
   option (gogoproto.goproto_stringer) = false;
 
   // delegator_address is the bech32-encoded address of the delegator.
-  string                     delegator_address     = 1 [(gogoproto.moretags) = "yaml:\"delegator_address\""];
+  string delegator_address = 1 [(gogoproto.moretags) = "yaml:\"delegator_address\""];
   // validator_src_address is the validator redelegation source operator address.
-  string                     validator_src_address = 2 [(gogoproto.moretags) = "yaml:\"validator_src_address\""];
+  string validator_src_address = 2 [(gogoproto.moretags) = "yaml:\"validator_src_address\""];
   // validator_dst_address is the validator redelegation destination operator address.
-  string                     validator_dst_address = 3 [(gogoproto.moretags) = "yaml:\"validator_dst_address\""];
+  string validator_dst_address = 3 [(gogoproto.moretags) = "yaml:\"validator_dst_address\""];
   // entries are the redelegation entries.
-  repeated RedelegationEntry entries               = 4 [(gogoproto.nullable) = false]; // redelegation entries
+  repeated RedelegationEntry entries = 4 [(gogoproto.nullable) = false]; // redelegation entries
 }
 
 // Params defines the parameters for the staking module.
@@ -275,13 +275,13 @@ message Params {
   google.protobuf.Duration unbonding_time = 1
       [(gogoproto.nullable) = false, (gogoproto.stdduration) = true, (gogoproto.moretags) = "yaml:\"unbonding_time\""];
   // max_validators is the maximum number of validators.
-  uint32 max_validators     = 2 [(gogoproto.moretags) = "yaml:\"max_validators\""];
+  uint32 max_validators = 2 [(gogoproto.moretags) = "yaml:\"max_validators\""];
   // max_entries is the max entries for either unbonding delegation or redelegation (per pair/trio).
-  uint32 max_entries        = 3 [(gogoproto.moretags) = "yaml:\"max_entries\""];
+  uint32 max_entries = 3 [(gogoproto.moretags) = "yaml:\"max_entries\""];
   // historical_entries is the number of historical entries to persist.
   uint32 historical_entries = 4 [(gogoproto.moretags) = "yaml:\"historical_entries\""];
   // bond_denom defines the bondable coin denomination.
-  string bond_denom         = 5 [(gogoproto.moretags) = "yaml:\"bond_denom\""];
+  string bond_denom = 5 [(gogoproto.moretags) = "yaml:\"bond_denom\""];
 }
 
 // DelegationResponse is equivalent to Delegation except that it contains a

--- a/pb-proto-java/src/main/proto/cosmos/tx/v1beta1/service.proto
+++ b/pb-proto-java/src/main/proto/cosmos/tx/v1beta1/service.proto
@@ -8,7 +8,7 @@ import "gogoproto/gogo.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 
 option (gogoproto.goproto_registration) = true;
-option go_package = "github.com/cosmos/cosmos-sdk/types/tx";
+option go_package                       = "github.com/cosmos/cosmos-sdk/types/tx";
 
 // Service defines a gRPC service for interacting with transactions.
 service Service {
@@ -43,7 +43,7 @@ message GetTxsEventRequest {
   repeated string events = 1;
   // pagination defines an pagination for the request.
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
-  OrderBy order_by = 3;
+  OrderBy                               order_by   = 3;
 }
 
 // OrderBy defines the sorting order
@@ -51,9 +51,9 @@ enum OrderBy {
   // ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults to ASC in this case.
   ORDER_BY_UNSPECIFIED = 0;
   // ORDER_BY_ASC defines ascending order
-  ORDER_BY_ASC     = 1;
+  ORDER_BY_ASC = 1;
   // ORDER_BY_DESC defines descending order
-  ORDER_BY_DESC    = 2;
+  ORDER_BY_DESC = 2;
 }
 
 // GetTxsEventResponse is the response type for the Service.TxsByEvents
@@ -101,7 +101,10 @@ message BroadcastTxResponse {
 // RPC method.
 message SimulateRequest {
   // tx is the transaction to simulate.
-  cosmos.tx.v1beta1.Tx tx = 1;
+  // Deprecated. Send raw tx bytes instead.
+  cosmos.tx.v1beta1.Tx tx = 1 [deprecated = true];
+  // tx_bytes is the raw transaction.
+  bytes tx_bytes = 2;
 }
 
 // SimulateResponse is the response type for the

--- a/pb-proto-java/src/main/proto/cosmos/tx/v1beta1/tx.proto
+++ b/pb-proto-java/src/main/proto/cosmos/tx/v1beta1/tx.proto
@@ -74,7 +74,9 @@ message TxBody {
   // transaction.
   repeated google.protobuf.Any messages = 1;
 
-  // memo is any arbitrary memo to be added to the transaction
+  // memo is any arbitrary note/comment to be added to the transaction.
+  // WARNING: in clients, any publicly exposed text should not be called memo,
+  // but should be called `note` instead (see https://github.com/cosmos/cosmos-sdk/issues/9122).
   string memo = 2;
 
   // timeout is the block height after which this transaction will not

--- a/pb-proto-java/src/main/proto/cosmos/upgrade/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/upgrade/v1beta1/query.proto
@@ -23,8 +23,16 @@ service Query {
   // as a trusted kernel for the next version of this chain. It will only be
   // stored at the last height of this chain.
   // UpgradedConsensusState RPC not supported with legacy querier
+  // This rpc is deprecated now that IBC has its own replacement
+  // (https://github.com/cosmos/ibc-go/blob/2c880a22e9f9cc75f62b527ca94aa75ce1106001/proto/ibc/core/client/v1/query.proto#L54)
   rpc UpgradedConsensusState(QueryUpgradedConsensusStateRequest) returns (QueryUpgradedConsensusStateResponse) {
+    option deprecated            = true;
     option (google.api.http).get = "/cosmos/upgrade/v1beta1/upgraded_consensus_state/{last_height}";
+  }
+
+  // ModuleVersions queries the list of module versions from state.
+  rpc ModuleVersions(QueryModuleVersionsRequest) returns (QueryModuleVersionsResponse) {
+    option (google.api.http).get = "/cosmos/upgrade/v1beta1/module_versions";
   }
 }
 
@@ -56,6 +64,8 @@ message QueryAppliedPlanResponse {
 // QueryUpgradedConsensusStateRequest is the request type for the Query/UpgradedConsensusState
 // RPC method.
 message QueryUpgradedConsensusStateRequest {
+  option deprecated = true;
+
   // last height of the current chain must be sent in request
   // as this is the height under which next consensus state is stored
   int64 last_height = 1;
@@ -64,5 +74,24 @@ message QueryUpgradedConsensusStateRequest {
 // QueryUpgradedConsensusStateResponse is the response type for the Query/UpgradedConsensusState
 // RPC method.
 message QueryUpgradedConsensusStateResponse {
-  google.protobuf.Any upgraded_consensus_state = 1;
+  option deprecated = true;
+  reserved 1;
+
+  bytes upgraded_consensus_state = 2;
+}
+
+// QueryModuleVersionsRequest is the request type for the Query/ModuleVersions
+// RPC method.
+message QueryModuleVersionsRequest {
+  // module_name is a field to query a specific module
+  // consensus version from state. Leaving this empty will
+  // fetch the full list of module versions from state
+  string module_name = 1;
+}
+
+// QueryModuleVersionsResponse is the response type for the Query/ModuleVersions
+// RPC method.
+message QueryModuleVersionsResponse {
+  // module_versions is a list of module names with their consensus versions.
+  repeated ModuleVersion module_versions = 1;
 }

--- a/pb-proto-java/src/main/proto/cosmos/upgrade/v1beta1/upgrade.proto
+++ b/pb-proto-java/src/main/proto/cosmos/upgrade/v1beta1/upgrade.proto
@@ -5,13 +5,13 @@ import "google/protobuf/any.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package                       = "github.com/cosmos/cosmos-sdk/x/upgrade/types";
-option (gogoproto.goproto_stringer_all) = false;
-option (gogoproto.goproto_getters_all)  = false;
+option go_package                      = "github.com/cosmos/cosmos-sdk/x/upgrade/types";
+option (gogoproto.goproto_getters_all) = false;
 
 // Plan specifies information about a planned upgrade and when it should occur.
 message Plan {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
+  option (gogoproto.goproto_stringer) = false;
 
   // Sets the name for the upgrade. This name will be used by the upgraded
   // version of the software to apply any special "on-upgrade" commands during
@@ -22,9 +22,10 @@ message Plan {
   // reached and the software will exit.
   string name = 1;
 
-  // The time after which the upgrade must be performed.
-  // Leave set to its zero value to use a pre-defined Height instead.
-  google.protobuf.Timestamp time = 2 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+  // Deprecated: Time based upgrades have been deprecated. Time based upgrade logic
+  // has been removed from the SDK.
+  // If this field is not empty, an error will be thrown.
+  google.protobuf.Timestamp time = 2 [deprecated = true, (gogoproto.stdtime) = true, (gogoproto.nullable) = false];
 
   // The height at which the upgrade must be performed.
   // Only used if Time is not set.
@@ -34,18 +35,18 @@ message Plan {
   // such as a git commit that validators could automatically upgrade to
   string info = 4;
 
-  // IBC-enabled chains can opt-in to including the upgraded client state in its upgrade plan
-  // This will make the chain commit to the correct upgraded (self) client state before the upgrade occurs,
-  // so that connecting chains can verify that the new upgraded client is valid by verifying a proof on the
-  // previous version of the chain.
-  // This will allow IBC connections to persist smoothly across planned chain upgrades
-  google.protobuf.Any upgraded_client_state = 5 [(gogoproto.moretags) = "yaml:\"upgraded_client_state\""];
+  // Deprecated: UpgradedClientState field has been deprecated. IBC upgrade logic has been
+  // moved to the IBC module in the sub module 02-client.
+  // If this field is not empty, an error will be thrown.
+  google.protobuf.Any upgraded_client_state = 5
+      [deprecated = true, (gogoproto.moretags) = "yaml:\"upgraded_client_state\""];
 }
 
 // SoftwareUpgradeProposal is a gov Content type for initiating a software
 // upgrade.
 message SoftwareUpgradeProposal {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
+  option (gogoproto.goproto_stringer) = false;
 
   string title       = 1;
   string description = 2;
@@ -55,8 +56,21 @@ message SoftwareUpgradeProposal {
 // CancelSoftwareUpgradeProposal is a gov Content type for cancelling a software
 // upgrade.
 message CancelSoftwareUpgradeProposal {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
+  option (gogoproto.goproto_stringer) = false;
 
   string title       = 1;
   string description = 2;
+}
+
+// ModuleVersion specifies a module and its consensus version.
+message ModuleVersion {
+  option (gogoproto.equal)            = true;
+  option (gogoproto.goproto_stringer) = true;
+
+  // name of the app module
+  string name = 1;
+
+  // consensus version of the app module
+  uint64 version = 2;
 }

--- a/pb-proto-java/src/main/proto/cosmos/vesting/v1beta1/vesting.proto
+++ b/pb-proto-java/src/main/proto/cosmos/vesting/v1beta1/vesting.proto
@@ -71,3 +71,13 @@ message PeriodicVestingAccount {
   int64              start_time           = 2 [(gogoproto.moretags) = "yaml:\"start_time\""];
   repeated Period vesting_periods = 3 [(gogoproto.moretags) = "yaml:\"vesting_periods\"", (gogoproto.nullable) = false];
 }
+
+// PermanentLockedAccount implements the VestingAccount interface. It does
+// not ever release coins, locking them indefinitely. Coins in this account can
+// still be used for delegating and for governance votes even while locked.
+message PermanentLockedAccount {
+  option (gogoproto.goproto_getters)  = false;
+  option (gogoproto.goproto_stringer) = false;
+
+  BaseVestingAccount base_vesting_account = 1 [(gogoproto.embed) = true];
+}

--- a/pb-proto-java/src/main/proto/provenance/marker/v1/accessgrant.proto
+++ b/pb-proto-java/src/main/proto/provenance/marker/v1/accessgrant.proto
@@ -41,6 +41,6 @@ enum Access {
   // ACCESS_ADMIN is the ability to add access grants for accounts to the list of marker permissions.
   ACCESS_ADMIN = 6 [(gogoproto.enumvalue_customname) = "Admin"];
   // ACCESS_TRANSFER is the ability to invoke a send operation using the marker module to facilitate exchange.
-  // This capability is useful when the marker denomination has "send enabled = false" preventing normal bank transfer
+  // This access right is only supported on RESTRICTED markers.
   ACCESS_TRANSFER = 7 [(gogoproto.enumvalue_customname) = "Transfer"];
 }

--- a/pb-proto-java/src/main/proto/provenance/marker/v1/authz.proto
+++ b/pb-proto-java/src/main/proto/provenance/marker/v1/authz.proto
@@ -1,0 +1,19 @@
+package provenance.marker.v1;
+
+import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
+import "cosmos/base/v1beta1/coin.proto";
+
+option go_package = "github.com/provenance-io/provenance/x/marker/types";
+option java_package        = "io.provenance.marker.v1";
+option java_multiple_files = true;
+
+// MarkerTransferAuthorization gives the grantee permissions to execute
+// a marker transfer on behalf of the granter's account.
+message MarkerTransferAuthorization {
+    option (cosmos_proto.implements_interface) = "Authorization";
+
+    // transfer_limit is the total amount the grantee can transfer
+    repeated cosmos.base.v1beta1.Coin transfer_limit = 1
+    [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+}

--- a/pb-proto-java/src/main/proto/provenance/marker/v1/marker.proto
+++ b/pb-proto-java/src/main/proto/provenance/marker/v1/marker.proto
@@ -178,6 +178,8 @@ message EventMarkerSetDenomMetadata {
   string                  metadata_display     = 3;
   repeated EventDenomUnit metadata_denom_units = 4;
   string                  administrator        = 5;
+  string                  metadata_name        = 6;
+  string                  metadata_symbol      = 7;
 }
 
 // EventDenomUnit denom units for set denom metadata event

--- a/pb-proto-java/src/main/proto/provenance/marker/v1/proposals.proto
+++ b/pb-proto-java/src/main/proto/provenance/marker/v1/proposals.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package provenance.marker.v1;
 
 import "gogoproto/gogo.proto";
+import "cosmos/bank/v1beta1/bank.proto";
 import "cosmos/base/v1beta1/coin.proto";
 import "provenance/marker/v1/marker.proto";
 import "provenance/marker/v1/accessgrant.proto";
@@ -39,7 +40,7 @@ message SupplyIncreaseProposal {
   string                   description = 2;
   cosmos.base.v1beta1.Coin amount      = 3
       [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Coin"];
-  string target_adddress = 4; // an optional target address for the minted coin from this request
+  string target_address = 4; // an optional target address for the minted coin from this request
 }
 
 // SupplyDecreaseProposal defines a governance proposal to administer a marker and decrease the total supply through
@@ -99,5 +100,15 @@ message WithdrawEscrowProposal {
   string   denom                           = 3;
   repeated cosmos.base.v1beta1.Coin amount = 4
       [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
-  string target_adddress = 5;
+  string target_address = 5;
+}
+
+// SetDenomMetadataProposal defines a governance proposal to set the metadata for a denom
+message SetDenomMetadataProposal {
+  option (gogoproto.goproto_stringer) = false;
+
+  string                       title       = 1;
+  string                       description = 2;
+  cosmos.bank.v1beta1.Metadata metadata    = 3
+      [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/x/bank/types.Metadata"];
 }

--- a/pb-proto-java/src/main/proto/provenance/metadata/v1/objectstore.proto
+++ b/pb-proto-java/src/main/proto/provenance/metadata/v1/objectstore.proto
@@ -13,6 +13,8 @@ message ObjectStoreLocator {
   string owner = 1;
   // locator endpoint uri
   string locator_uri = 2;
+  // owners encryption key address
+  string encryption_key = 3;
 }
 
 // Params defines the parameters for the metadata-locator module methods.

--- a/pb-proto-java/src/main/proto/provenance/metadata/v1/query.proto
+++ b/pb-proto-java/src/main/proto/provenance/metadata/v1/query.proto
@@ -60,12 +60,26 @@ service Query {
   //
   // The scope_id can either be scope uuid, e.g. 91978ba2-5f35-459a-86a7-feca1b0512e0 or a scope address, e.g.
   // scope1qzge0zaztu65tx5x5llv5xc9ztsqxlkwel. Similarly, the session_id can either be a uuid or session address, e.g.
-  // session1qxge0zaztu65tx5x5llv5xc9zts9sqlch3sxwn44j50jzgt8rshvqyfrjcr.
+  // session1qxge0zaztu65tx5x5llv5xc9zts9sqlch3sxwn44j50jzgt8rshvqyfrjcr. The record_addr, if provided, must be a
+  // bech32 record address, e.g. record1q2ge0zaztu65tx5x5llv5xc9ztsw42dq2jdvmdazuwzcaddhh8gmu3mcze3.
   //
   // * If only a scope_id is provided, all sessions in that scope are returned.
   // * If only a session_id is provided, it must be an address, and that single session is returned.
-  // * If both are provided, that single session is returned.
-  // * If both scope_id and session_id are addresses, and they don't refer to the same scope, a bad request is returned.
+  // * If the session_id is a uuid, then either a scope_id or record_addr must also be provided, and that single session
+  // is returned.
+  // * If only a record_addr is provided, the session containing that record will be returned.
+  // * If a record_name is provided then either a scope_id, session_id as an address, or record_addr must also be
+  // provided, and the session containing that record will be returned.
+  //
+  // A bad request is returned if:
+  // * The session_id is a uuid and is provided without a scope_id or record_addr.
+  // * A record_name is provided without any way to identify the scope (e.g. a scope_id, a session_id as an address, or
+  // a record_addr).
+  // * Two or more of scope_id, session_id as an address, and record_addr are provided and don't all refer to the same
+  // scope.
+  // * A record_addr (or scope_id and record_name) is provided with a session_id and that session does not contain such
+  // a record.
+  // * A record_addr and record_name are both provided, but reference different records.
   //
   // By default, the scope and records are not included.
   // Set include_scope and/or include_records to true to include the scope and/or records.
@@ -74,7 +88,9 @@ service Query {
       get: "/provenance/metadata/v1/session/{session_id}",
       additional_bindings: [
         {get: "/provenance/metadata/v1/scope/{scope_id}/sessions"},
-        {get: "/provenance/metadata/v1/scope/{scope_id}/session/{session_id}"}
+        {get: "/provenance/metadata/v1/scope/{scope_id}/session/{session_id}"},
+        {get: "/provenance/metadata/v1/record/{record_addr}/session"},
+        {get: "/provenance/metadata/v1/scope/{scope_id}/record/{record_name}/session"}
       ]
     };
   }
@@ -298,6 +314,10 @@ message SessionsRequest {
   // session1qxge0zaztu65tx5x5llv5xc9zts9sqlch3sxwn44j50jzgt8rshvqyfrjcr. This can only be a uuid if a scope_id is also
   // provided.
   string session_id = 2 [(gogoproto.moretags) = "yaml:\"session_id\""];
+  // record_addr is a bech32 record address, e.g. record1q2ge0zaztu65tx5x5llv5xc9ztsw42dq2jdvmdazuwzcaddhh8gmu3mcze3.
+  string record_addr = 3 [(gogoproto.moretags) = "yaml:\"record_addr\""];
+  // record_name is the name of the record to find the session for in the provided scope.
+  string record_name = 4 [(gogoproto.moretags) = "yaml:\"record_name\""];
 
   // include_scope is a flag for whether or not the scope containing these sessions should be included.
   bool include_scope = 10 [(gogoproto.moretags) = "yaml:\"include_scope\""];

--- a/pb-proto-java/src/main/proto/tendermint/abci/types.proto
+++ b/pb-proto-java/src/main/proto/tendermint/abci/types.proto
@@ -222,7 +222,7 @@ message ResponseDeliverTx {
   int64          gas_wanted = 5 [json_name = "gas_wanted"];
   int64          gas_used   = 6 [json_name = "gas_used"];
   repeated Event events     = 7
-      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"]; // nondeterministic
   string codespace = 8;
 }
 


### PR DESCRIPTION
Bumps to the following versions:

```kotlin
    const val cosmos = "0.44.0"
    const val wasmd = "v0.19.0"
    const val pbProto = "1.7.0"
```

Moves wasmd from Cosmos to the provenance-io fork.