### PR TITLE
Bump versions for provenance, wasmd, and cosmwasm

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
-    const val cosmos = "0.44.0"
-    const val wasmd = "v0.19.0"
-    const val pbProto = "1.7.0"
+    const val cosmos = "0.45.0"
+    const val wasmd = "v0.22.0"
+    const val pbProto = "1.8.0-rc2"
     const val protobuf = "3.6.1"
     const val protoUtil = "0.1.5"
     const val grpc = "1.39.0"

--- a/pb-proto-java/build.gradle.kts
+++ b/pb-proto-java/build.gradle.kts
@@ -84,7 +84,7 @@ val downloadAndUnzipProvenanceProtos = tasks.create<Copy>("downloadAndUnzipProve
 }
 
 val downloadWasmProtos = tasks.create<Download>("downloadWasmProtos") {
-    src("https://github.com/provenance-io/wasmd/archive/refs/tags/${Versions.wasmd}.tar.gz")
+    src("https://github.com/CosmWasm/wasmd/archive/refs/tags/${Versions.wasmd}.tar.gz")
     dest(File(buildDir, "${Versions.wasmd}.tar.gz"))
     onlyIfModified(true)
 }

--- a/pb-proto-java/src/main/proto/confio/proofs.proto
+++ b/pb-proto-java/src/main/proto/confio/proofs.proto
@@ -13,6 +13,7 @@ enum HashOp {
     KECCAK = 3;
     RIPEMD160 = 4;
     BITCOIN = 5;  // ripemd160(sha256(x))
+    SHA512_256 = 6;
 }
 
 /**

--- a/pb-proto-java/src/main/proto/cosmos/auth/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/auth/v1beta1/query.proto
@@ -13,6 +13,8 @@ option go_package = "github.com/cosmos/cosmos-sdk/x/auth/types";
 // Query defines the gRPC querier service.
 service Query {
   // Accounts returns all the existing accounts
+  //
+  // Since: cosmos-sdk 0.43
   rpc Accounts(QueryAccountsRequest) returns (QueryAccountsResponse) {
     option (google.api.http).get = "/cosmos/auth/v1beta1/accounts";
   }
@@ -29,12 +31,16 @@ service Query {
 }
 
 // QueryAccountsRequest is the request type for the Query/Accounts RPC method.
+//
+// Since: cosmos-sdk 0.43
 message QueryAccountsRequest {
   // pagination defines an optional pagination for the request.
   cosmos.base.query.v1beta1.PageRequest pagination = 1;
 }
 
 // QueryAccountsResponse is the response type for the Query/Accounts RPC method.
+//
+// Since: cosmos-sdk 0.43
 message QueryAccountsResponse {
   // accounts are the existing accounts
   repeated google.protobuf.Any accounts = 1 [(cosmos_proto.accepts_interface) = "AccountI"];

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/authz.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/authz.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.authz.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/event.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/event.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.authz.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/genesis.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/genesis.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.authz.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/query.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.authz.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/tx.proto
+++ b/pb-proto-java/src/main/proto/cosmos/authz/v1beta1/tx.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.authz.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/authz.proto
+++ b/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/authz.proto
@@ -9,6 +9,8 @@ option go_package = "github.com/cosmos/cosmos-sdk/x/bank/types";
 
 // SendAuthorization allows the grantee to spend up to spend_limit coins from
 // the granter's account.
+//
+// Since: cosmos-sdk 0.43
 message SendAuthorization {
   option (cosmos_proto.implements_interface) = "Authorization";
 

--- a/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/bank.proto
+++ b/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/bank.proto
@@ -85,8 +85,12 @@ message Metadata {
   // displayed in clients.
   string display = 4;
   // name defines the name of the token (eg: Cosmos Atom)
+  //
+  // Since: cosmos-sdk 0.43
   string name = 5;
   // symbol is the token symbol usually shown on exchanges (eg: ATOM). This can
   // be the same as the display.
+  //
+  // Since: cosmos-sdk 0.43
   string symbol = 6;
 }

--- a/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/bank/v1beta1/query.proto
@@ -13,7 +13,7 @@ option go_package = "github.com/cosmos/cosmos-sdk/x/bank/types";
 service Query {
   // Balance queries the balance of a single coin for a single account.
   rpc Balance(QueryBalanceRequest) returns (QueryBalanceResponse) {
-    option (google.api.http).get = "/cosmos/bank/v1beta1/balances/{address}/{denom}";
+    option (google.api.http).get = "/cosmos/bank/v1beta1/balances/{address}/by_denom";
   }
 
   // AllBalances queries the balance of all coins for a single account.
@@ -49,7 +49,7 @@ service Query {
 
 // QueryBalanceRequest is the request type for the Query/Balance RPC method.
 message QueryBalanceRequest {
-  option (gogoproto.equal)           = false;
+  option (gogoproto.equal) = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the address to query balances for.
@@ -67,7 +67,7 @@ message QueryBalanceResponse {
 
 // QueryBalanceRequest is the request type for the Query/AllBalances RPC method.
 message QueryAllBalancesRequest {
-  option (gogoproto.equal)           = false;
+  option (gogoproto.equal) = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the address to query balances for.
@@ -82,7 +82,7 @@ message QueryAllBalancesRequest {
 message QueryAllBalancesResponse {
   // balances is the balances of all the coins.
   repeated cosmos.base.v1beta1.Coin balances = 1
-      [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+  [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -91,10 +91,12 @@ message QueryAllBalancesResponse {
 // QueryTotalSupplyRequest is the request type for the Query/TotalSupply RPC
 // method.
 message QueryTotalSupplyRequest {
-  option (gogoproto.equal)           = false;
+  option (gogoproto.equal) = false;
   option (gogoproto.goproto_getters) = false;
 
   // pagination defines an optional pagination for the request.
+  //
+  // Since: cosmos-sdk 0.43
   cosmos.base.query.v1beta1.PageRequest pagination = 1;
 }
 
@@ -103,9 +105,11 @@ message QueryTotalSupplyRequest {
 message QueryTotalSupplyResponse {
   // supply is the supply of the coins
   repeated cosmos.base.v1beta1.Coin supply = 1
-      [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+  [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
 
   // pagination defines the pagination in the response.
+  //
+  // Since: cosmos-sdk 0.43
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 

--- a/pb-proto-java/src/main/proto/cosmos/base/abci/v1beta1/abci.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/abci/v1beta1/abci.proto
@@ -39,6 +39,13 @@ message TxResponse {
   // the timestamps of the valid votes in the block.LastCommit. For height == 1,
   // it's genesis time.
   string timestamp = 12;
+  // Events defines all the events emitted by processing a transaction. Note,
+  // these events include those emitted by processing all the messages and those
+  // emitted from the ante handler. Whereas Logs contains the events, with
+  // additional metadata, emitted only by processing the messages.
+  //
+  // Since: cosmos-sdk 0.42.11, 0.44.5, 0.45
+  repeated tendermint.abci.Event events = 13 [(gogoproto.nullable) = false];
 }
 
 // ABCIMessageLog defines a structure containing an indexed tx ABCI message log.

--- a/pb-proto-java/src/main/proto/cosmos/base/query/v1beta1/pagination.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/query/v1beta1/pagination.proto
@@ -32,6 +32,8 @@ message PageRequest {
   bool count_total = 4;
 
   // reverse is set to true if results are to be returned in the descending order.
+  //
+  // Since: cosmos-sdk 0.43
   bool reverse = 5;
 }
 

--- a/pb-proto-java/src/main/proto/cosmos/base/reflection/v2alpha1/reflection.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/reflection/v2alpha1/reflection.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.base.reflection.v2alpha1;
 

--- a/pb-proto-java/src/main/proto/cosmos/base/store/v1beta1/listening.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/store/v1beta1/listening.proto
@@ -6,6 +6,8 @@ option go_package = "github.com/cosmos/cosmos-sdk/store/types";
 // StoreKVPair is a KVStore KVPair used for listening to state changes (Sets and Deletes)
 // It optionally includes the StoreKey for the originating KVStore and a Boolean flag to distinguish between Sets and
 // Deletes
+//
+// Since: cosmos-sdk 0.43
 message StoreKVPair {
   string store_key = 1; // the store key for the KVStore this pair originates from
   bool delete      = 2; // true indicates a delete operation, false indicates a set operation

--- a/pb-proto-java/src/main/proto/cosmos/base/tendermint/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/base/tendermint/v1beta1/query.proto
@@ -123,6 +123,7 @@ message VersionInfo {
   string          build_tags         = 5;
   string          go_version         = 6;
   repeated Module build_deps         = 7;
+  // Since: cosmos-sdk 0.43
   string          cosmos_sdk_version = 8;
 }
 

--- a/pb-proto-java/src/main/proto/cosmos/crypto/secp256r1/keys.proto
+++ b/pb-proto-java/src/main/proto/cosmos/crypto/secp256r1/keys.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.crypto.secp256r1;
 

--- a/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/feegrant.proto
+++ b/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/feegrant.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.feegrant.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/genesis.proto
+++ b/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/genesis.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.feegrant.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/query.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.feegrant.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/tx.proto
+++ b/pb-proto-java/src/main/proto/cosmos/feegrant/v1beta1/tx.proto
@@ -1,3 +1,4 @@
+// Since: cosmos-sdk 0.43
 syntax = "proto3";
 package cosmos.feegrant.v1beta1;
 

--- a/pb-proto-java/src/main/proto/cosmos/gov/v1beta1/gov.proto
+++ b/pb-proto-java/src/main/proto/cosmos/gov/v1beta1/gov.proto
@@ -30,6 +30,8 @@ enum VoteOption {
 }
 
 // WeightedVoteOption defines a unit of vote for vote split.
+//
+// Since: cosmos-sdk 0.43
 message WeightedVoteOption {
   VoteOption option = 1;
   string     weight = 2 [
@@ -135,6 +137,7 @@ message Vote {
   // if and only if `len(options) == 1` and that option has weight 1. In all
   // other cases, this field will default to VOTE_OPTION_UNSPECIFIED.
   VoteOption                  option  = 3 [deprecated = true];
+  // Since: cosmos-sdk 0.43
   repeated WeightedVoteOption options = 4 [(gogoproto.nullable) = false];
 }
 

--- a/pb-proto-java/src/main/proto/cosmos/gov/v1beta1/tx.proto
+++ b/pb-proto-java/src/main/proto/cosmos/gov/v1beta1/tx.proto
@@ -18,6 +18,8 @@ service Msg {
   rpc Vote(MsgVote) returns (MsgVoteResponse);
 
   // VoteWeighted defines a method to add a weighted vote on a specific proposal.
+  //
+  // Since: cosmos-sdk 0.43
   rpc VoteWeighted(MsgVoteWeighted) returns (MsgVoteWeightedResponse);
 
   // Deposit defines a method to add deposit on a specific proposal.
@@ -62,6 +64,8 @@ message MsgVote {
 message MsgVoteResponse {}
 
 // MsgVoteWeighted defines a message to cast a vote.
+//
+// Since: cosmos-sdk 0.43
 message MsgVoteWeighted {
   option (gogoproto.equal)            = false;
   option (gogoproto.goproto_stringer) = false;
@@ -74,6 +78,8 @@ message MsgVoteWeighted {
 }
 
 // MsgVoteWeightedResponse defines the Msg/VoteWeighted response type.
+//
+// Since: cosmos-sdk 0.43
 message MsgVoteWeightedResponse {}
 
 // MsgDeposit defines a message to submit a deposit to an existing proposal.

--- a/pb-proto-java/src/main/proto/cosmos/staking/v1beta1/authz.proto
+++ b/pb-proto-java/src/main/proto/cosmos/staking/v1beta1/authz.proto
@@ -8,6 +8,8 @@ import "cosmos/base/v1beta1/coin.proto";
 option go_package = "github.com/cosmos/cosmos-sdk/x/staking/types";
 
 // StakeAuthorization defines authorization for delegate/undelegate/redelegate.
+//
+// Since: cosmos-sdk 0.43
 message StakeAuthorization {
   option (cosmos_proto.implements_interface) = "Authorization";
 
@@ -31,6 +33,8 @@ message StakeAuthorization {
 }
 
 // AuthorizationType defines the type of staking module authorization type
+//
+// Since: cosmos-sdk 0.43
 enum AuthorizationType {
   // AUTHORIZATION_TYPE_UNSPECIFIED specifies an unknown authorization type
   AUTHORIZATION_TYPE_UNSPECIFIED = 0;

--- a/pb-proto-java/src/main/proto/cosmos/tx/v1beta1/service.proto
+++ b/pb-proto-java/src/main/proto/cosmos/tx/v1beta1/service.proto
@@ -104,6 +104,8 @@ message SimulateRequest {
   // Deprecated. Send raw tx bytes instead.
   cosmos.tx.v1beta1.Tx tx = 1 [deprecated = true];
   // tx_bytes is the raw transaction.
+  //
+  // Since: cosmos-sdk 0.43
   bytes tx_bytes = 2;
 }
 

--- a/pb-proto-java/src/main/proto/cosmos/upgrade/v1beta1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmos/upgrade/v1beta1/query.proto
@@ -31,6 +31,8 @@ service Query {
   }
 
   // ModuleVersions queries the list of module versions from state.
+  //
+  // Since: cosmos-sdk 0.43
   rpc ModuleVersions(QueryModuleVersionsRequest) returns (QueryModuleVersionsResponse) {
     option (google.api.http).get = "/cosmos/upgrade/v1beta1/module_versions";
   }
@@ -77,11 +79,14 @@ message QueryUpgradedConsensusStateResponse {
   option deprecated = true;
   reserved 1;
 
+  // Since: cosmos-sdk 0.43
   bytes upgraded_consensus_state = 2;
 }
 
 // QueryModuleVersionsRequest is the request type for the Query/ModuleVersions
 // RPC method.
+//
+// Since: cosmos-sdk 0.43
 message QueryModuleVersionsRequest {
   // module_name is a field to query a specific module
   // consensus version from state. Leaving this empty will
@@ -91,6 +96,8 @@ message QueryModuleVersionsRequest {
 
 // QueryModuleVersionsResponse is the response type for the Query/ModuleVersions
 // RPC method.
+//
+// Since: cosmos-sdk 0.43
 message QueryModuleVersionsResponse {
   // module_versions is a list of module names with their consensus versions.
   repeated ModuleVersion module_versions = 1;

--- a/pb-proto-java/src/main/proto/cosmos/upgrade/v1beta1/upgrade.proto
+++ b/pb-proto-java/src/main/proto/cosmos/upgrade/v1beta1/upgrade.proto
@@ -64,6 +64,8 @@ message CancelSoftwareUpgradeProposal {
 }
 
 // ModuleVersion specifies a module and its consensus version.
+//
+// Since: cosmos-sdk 0.43
 message ModuleVersion {
   option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = true;

--- a/pb-proto-java/src/main/proto/cosmos/vesting/v1beta1/vesting.proto
+++ b/pb-proto-java/src/main/proto/cosmos/vesting/v1beta1/vesting.proto
@@ -75,6 +75,8 @@ message PeriodicVestingAccount {
 // PermanentLockedAccount implements the VestingAccount interface. It does
 // not ever release coins, locking them indefinitely. Coins in this account can
 // still be used for delegating and for governance votes even while locked.
+//
+// Since: cosmos-sdk 0.43
 message PermanentLockedAccount {
   option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;

--- a/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/ibc.proto
+++ b/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/ibc.proto
@@ -20,8 +20,9 @@ message MsgIBCSend {
   uint64 timeout_timestamp = 5
       [ (gogoproto.moretags) = "yaml:\"timeout_timestamp\"" ];
 
-  // data is the payload to transfer
-  bytes data = 6 [ (gogoproto.casttype) = "encoding/json.RawMessage" ];
+  // Data is the payload to transfer. We must not make assumption what format or
+  // content is in here.
+  bytes data = 6;
 }
 
 // MsgIBCCloseChannel port and channel need to be owned by the contract

--- a/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/proposal.proto
+++ b/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/proposal.proto
@@ -42,7 +42,7 @@ message InstantiateContractProposal {
   // Label is optional metadata to be stored with a constract instance.
   string label = 6;
   // Msg json encoded message to be passed to the contract on instantiation
-  bytes msg = 7;
+  bytes msg = 7 [ (gogoproto.casttype) = "RawContractMessage" ];
   // Funds coins that are transferred to the contract on instantiation
   repeated cosmos.base.v1beta1.Coin funds = 8 [
     (gogoproto.nullable) = false,
@@ -56,14 +56,46 @@ message MigrateContractProposal {
   string title = 1;
   // Description is a human readable text
   string description = 2;
+  // Note: skipping 3 as this was previously used for unneeded run_as
+
+  // Contract is the address of the smart contract
+  string contract = 4;
+  // CodeID references the new WASM codesudo
+  uint64 code_id = 5 [ (gogoproto.customname) = "CodeID" ];
+  // Msg json encoded message to be passed to the contract on migration
+  bytes msg = 6 [ (gogoproto.casttype) = "RawContractMessage" ];
+}
+
+// SudoContractProposal gov proposal content type to call sudo on a contract.
+message SudoContractProposal {
+  // Title is a short summary
+  string title = 1;
+  // Description is a human readable text
+  string description = 2;
+  // Contract is the address of the smart contract
+  string contract = 3;
+  // Msg json encoded message to be passed to the contract as sudo
+  bytes msg = 4 [ (gogoproto.casttype) = "RawContractMessage" ];
+}
+
+// ExecuteContractProposal gov proposal content type to call execute on a
+// contract.
+message ExecuteContractProposal {
+  // Title is a short summary
+  string title = 1;
+  // Description is a human readable text
+  string description = 2;
   // RunAs is the address that is passed to the contract's environment as sender
   string run_as = 3;
   // Contract is the address of the smart contract
   string contract = 4;
-  // CodeID references the new WASM code
-  uint64 code_id = 5 [ (gogoproto.customname) = "CodeID" ];
-  // Msg json encoded message to be passed to the contract on migration
-  bytes msg = 6;
+  // Msg json encoded message to be passed to the contract as execute
+  bytes msg = 5 [ (gogoproto.casttype) = "RawContractMessage" ];
+  // Funds coins that are transferred to the contract on instantiation
+  repeated cosmos.base.v1beta1.Coin funds = 6 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
 }
 
 // UpdateAdminProposal gov proposal content type to set an admin for a contract.

--- a/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/query.proto
+++ b/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/query.proto
@@ -53,6 +53,11 @@ service Query {
   rpc Codes(QueryCodesRequest) returns (QueryCodesResponse) {
     option (google.api.http).get = "/cosmwasm/wasm/v1/code";
   }
+
+  // PinnedCodes gets the pinned code ids
+  rpc PinnedCodes(QueryPinnedCodesRequest) returns (QueryPinnedCodesResponse) {
+    option (google.api.http).get = "/cosmwasm/wasm/v1/codes/pinned";
+  }
 }
 
 // QueryContractInfoRequest is the request type for the Query/ContractInfo RPC
@@ -149,14 +154,14 @@ message QuerySmartContractStateRequest {
   // address is the address of the contract
   string address = 1;
   // QueryData contains the query data passed to the contract
-  bytes query_data = 2;
+  bytes query_data = 2 [ (gogoproto.casttype) = "RawContractMessage" ];
 }
 
 // QuerySmartContractStateResponse is the response type for the
 // Query/SmartContractState RPC method
 message QuerySmartContractStateResponse {
   // Data contains the json data returned from the smart contract
-  bytes data = 1 [ (gogoproto.casttype) = "encoding/json.RawMessage" ];
+  bytes data = 1 [ (gogoproto.casttype) = "RawContractMessage" ];
 }
 
 // QueryCodeRequest is the request type for the Query/Code RPC method
@@ -197,6 +202,22 @@ message QueryCodesRequest {
 // QueryCodesResponse is the response type for the Query/Codes RPC method
 message QueryCodesResponse {
   repeated CodeInfoResponse code_infos = 1 [ (gogoproto.nullable) = false ];
+  // pagination defines the pagination in the response.
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryPinnedCodesRequest is the request type for the Query/PinnedCodes
+// RPC method
+message QueryPinnedCodesRequest {
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 2;
+}
+
+// QueryPinnedCodesResponse is the response type for the
+// Query/PinnedCodes RPC method
+message QueryPinnedCodesResponse {
+  repeated uint64 code_ids = 1
+      [ (gogoproto.nullable) = false, (gogoproto.customname) = "CodeIDs" ];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }

--- a/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/tx.proto
+++ b/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/tx.proto
@@ -55,7 +55,7 @@ message MsgInstantiateContract {
   // Label is optional metadata to be stored with a contract instance.
   string label = 4;
   // Msg json encoded message to be passed to the contract on instantiation
-  bytes msg = 5;
+  bytes msg = 5 [ (gogoproto.casttype) = "RawContractMessage" ];
   // Funds coins that are transferred to the contract on instantiation
   repeated cosmos.base.v1beta1.Coin funds = 6 [
     (gogoproto.nullable) = false,
@@ -77,7 +77,7 @@ message MsgExecuteContract {
   // Contract is the address of the smart contract
   string contract = 2;
   // Msg json encoded message to be passed to the contract
-  bytes msg = 3;
+  bytes msg = 3 [ (gogoproto.casttype) = "RawContractMessage" ];
   // Funds coins that are transferred to the contract on execution
   repeated cosmos.base.v1beta1.Coin funds = 5 [
     (gogoproto.nullable) = false,
@@ -100,7 +100,7 @@ message MsgMigrateContract {
   // CodeID references the new WASM code
   uint64 code_id = 3 [ (gogoproto.customname) = "CodeID" ];
   // Msg json encoded message to be passed to the contract on migration
-  bytes msg = 4;
+  bytes msg = 4 [ (gogoproto.casttype) = "RawContractMessage" ];
 }
 
 // MsgMigrateContractResponse returns contract migration result data.

--- a/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/types.proto
+++ b/pb-proto-java/src/main/proto/cosmwasm/wasm/v1/types.proto
@@ -117,7 +117,7 @@ message ContractCodeHistoryEntry {
   uint64 code_id = 2 [ (gogoproto.customname) = "CodeID" ];
   // Updated Tx position when the operation was executed.
   AbsoluteTxPosition updated = 3;
-  bytes msg = 4 [ (gogoproto.casttype) = "encoding/json.RawMessage" ];
+  bytes msg = 4 [ (gogoproto.casttype) = "RawContractMessage" ];
 }
 
 // AbsoluteTxPosition is a unique transaction position that allows for global

--- a/pb-proto-java/src/main/proto/ibc/applications/transfer/v1/genesis.proto
+++ b/pb-proto-java/src/main/proto/ibc/applications/transfer/v1/genesis.proto
@@ -1,10 +1,11 @@
 syntax = "proto3";
+
 package ibc.applications.transfer.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types";
 
-import "gogoproto/gogo.proto";
 import "ibc/applications/transfer/v1/transfer.proto";
+import "gogoproto/gogo.proto";
 
 // GenesisState defines the ibc-transfer genesis state
 message GenesisState {

--- a/pb-proto-java/src/main/proto/ibc/applications/transfer/v1/query.proto
+++ b/pb-proto-java/src/main/proto/ibc/applications/transfer/v1/query.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package ibc.applications.transfer.v1;
 
 import "gogoproto/gogo.proto";
@@ -6,23 +7,23 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "ibc/applications/transfer/v1/transfer.proto";
 import "google/api/annotations.proto";
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types";
 
 // Query provides defines the gRPC querier service.
 service Query {
   // DenomTrace queries a denomination trace information.
   rpc DenomTrace(QueryDenomTraceRequest) returns (QueryDenomTraceResponse) {
-    option (google.api.http).get = "/ibc/applications/transfer/v1beta1/denom_traces/{hash}";
+    option (google.api.http).get = "/ibc/apps/transfer/v1/denom_traces/{hash}";
   }
 
   // DenomTraces queries all denomination traces.
   rpc DenomTraces(QueryDenomTracesRequest) returns (QueryDenomTracesResponse) {
-    option (google.api.http).get = "/ibc/applications/transfer/v1beta1/denom_traces";
+    option (google.api.http).get = "/ibc/apps/transfer/v1/denom_traces";
   }
 
   // Params queries all parameters of the ibc-transfer module.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
-    option (google.api.http).get = "/ibc/applications/transfer/v1beta1/params";
+    option (google.api.http).get = "/ibc/apps/transfer/v1/params";
   }
 }
 

--- a/pb-proto-java/src/main/proto/ibc/applications/transfer/v1/transfer.proto
+++ b/pb-proto-java/src/main/proto/ibc/applications/transfer/v1/transfer.proto
@@ -1,23 +1,10 @@
 syntax = "proto3";
+
 package ibc.applications.transfer.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types";
 
 import "gogoproto/gogo.proto";
-
-// FungibleTokenPacketData defines a struct for the packet payload
-// See FungibleTokenPacketData spec:
-// https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer#data-structures
-message FungibleTokenPacketData {
-  // the token denomination to be transferred
-  string denom = 1;
-  // the token amount to be transferred
-  uint64 amount = 2;
-  // the sender address
-  string sender = 3;
-  // the recipient address on the destination chain
-  string receiver = 4;
-}
 
 // DenomTrace contains the base denomination for ICS20 fungible tokens and the
 // source tracing information path.

--- a/pb-proto-java/src/main/proto/ibc/applications/transfer/v1/tx.proto
+++ b/pb-proto-java/src/main/proto/ibc/applications/transfer/v1/tx.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.applications.transfer.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types";
 
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
@@ -15,7 +16,7 @@ service Msg {
 
 // MsgTransfer defines a msg to transfer fungible tokens (i.e Coins) between
 // ICS20 enabled chains. See ICS Spec here:
-// https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer#data-structures
+// https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#data-structures
 message MsgTransfer {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;

--- a/pb-proto-java/src/main/proto/ibc/core/channel/v1/channel.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/channel/v1/channel.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/client.proto";
@@ -137,7 +138,7 @@ message PacketState {
 // conflicts with other protobuf message formats used for acknowledgements.
 // The first byte of any message with this format will be the non-ASCII values
 // `0xaa` (result) or `0xb2` (error). Implemented as defined by ICS:
-// https://github.com/cosmos/ics/tree/master/spec/ics-004-channel-and-packet-semantics#acknowledgement-envelope
+// https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#acknowledgement-envelope
 message Acknowledgement {
   // response contains either a result or an error and must be non-empty
   oneof response {

--- a/pb-proto-java/src/main/proto/ibc/core/channel/v1/genesis.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/channel/v1/genesis.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/channel/v1/channel.proto";

--- a/pb-proto-java/src/main/proto/ibc/core/channel/v1/query.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/channel/v1/query.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.channel.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types";
 
 import "ibc/core/client/v1/client.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
@@ -8,88 +11,92 @@ import "google/api/annotations.proto";
 import "google/protobuf/any.proto";
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types";
-
 // Query provides defines the gRPC querier service
 service Query {
   // Channel queries an IBC Channel.
   rpc Channel(QueryChannelRequest) returns (QueryChannelResponse) {
-    option (google.api.http).get = "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/ports/{port_id}";
   }
 
   // Channels queries all the IBC channels of a chain.
   rpc Channels(QueryChannelsRequest) returns (QueryChannelsResponse) {
-    option (google.api.http).get = "/ibc/core/channel/v1beta1/channels";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels";
   }
 
   // ConnectionChannels queries all the channels associated with a connection
   // end.
   rpc ConnectionChannels(QueryConnectionChannelsRequest) returns (QueryConnectionChannelsResponse) {
-    option (google.api.http).get = "/ibc/core/channel/v1beta1/connections/{connection}/channels";
+    option (google.api.http).get = "/ibc/core/channel/v1/connections/{connection}/channels";
   }
 
   // ChannelClientState queries for the client state for the channel associated
   // with the provided channel identifiers.
   rpc ChannelClientState(QueryChannelClientStateRequest) returns (QueryChannelClientStateResponse) {
-    option (google.api.http).get = "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/client_state";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
+                                   "ports/{port_id}/client_state";
   }
 
   // ChannelConsensusState queries for the consensus state for the channel
   // associated with the provided channel identifiers.
   rpc ChannelConsensusState(QueryChannelConsensusStateRequest) returns (QueryChannelConsensusStateResponse) {
-    option (google.api.http).get =
-        "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/consensus_state/revision/"
-        "{revision_number}/height/{revision_height}";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
+                                   "ports/{port_id}/consensus_state/revision/"
+                                   "{revision_number}/height/{revision_height}";
   }
 
   // PacketCommitment queries a stored packet commitment hash.
   rpc PacketCommitment(QueryPacketCommitmentRequest) returns (QueryPacketCommitmentResponse) {
-    option (google.api.http).get =
-        "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/packet_commitments/{sequence}";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/ports/{port_id}/"
+                                   "packet_commitments/{sequence}";
   }
 
   // PacketCommitments returns all the packet commitments hashes associated
   // with a channel.
   rpc PacketCommitments(QueryPacketCommitmentsRequest) returns (QueryPacketCommitmentsResponse) {
-    option (google.api.http).get = "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/packet_commitments";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
+                                   "ports/{port_id}/packet_commitments";
   }
 
-  // PacketReceipt queries if a given packet sequence has been received on the queried chain
+  // PacketReceipt queries if a given packet sequence has been received on the
+  // queried chain
   rpc PacketReceipt(QueryPacketReceiptRequest) returns (QueryPacketReceiptResponse) {
-    option (google.api.http).get =
-        "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/packet_receipts/{sequence}";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
+                                   "ports/{port_id}/packet_receipts/{sequence}";
   }
 
   // PacketAcknowledgement queries a stored packet acknowledgement hash.
   rpc PacketAcknowledgement(QueryPacketAcknowledgementRequest) returns (QueryPacketAcknowledgementResponse) {
-    option (google.api.http).get =
-        "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/packet_acks/{sequence}";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
+                                   "ports/{port_id}/packet_acks/{sequence}";
   }
 
   // PacketAcknowledgements returns all the packet acknowledgements associated
   // with a channel.
   rpc PacketAcknowledgements(QueryPacketAcknowledgementsRequest) returns (QueryPacketAcknowledgementsResponse) {
-    option (google.api.http).get =
-        "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/packet_acknowledgements";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
+                                   "ports/{port_id}/packet_acknowledgements";
   }
 
   // UnreceivedPackets returns all the unreceived IBC packets associated with a
   // channel and sequences.
   rpc UnreceivedPackets(QueryUnreceivedPacketsRequest) returns (QueryUnreceivedPacketsResponse) {
-    option (google.api.http).get = "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/packet_commitments/"
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/ports/{port_id}/"
+                                   "packet_commitments/"
                                    "{packet_commitment_sequences}/unreceived_packets";
   }
 
-  // UnreceivedAcks returns all the unreceived IBC acknowledgements associated with a
-  // channel and sequences.
+  // UnreceivedAcks returns all the unreceived IBC acknowledgements associated
+  // with a channel and sequences.
   rpc UnreceivedAcks(QueryUnreceivedAcksRequest) returns (QueryUnreceivedAcksResponse) {
-    option (google.api.http).get = "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/packet_commitments/"
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
+                                   "ports/{port_id}/packet_commitments/"
                                    "{packet_ack_sequences}/unreceived_acks";
   }
 
   // NextSequenceReceive returns the next receive sequence for a given channel.
   rpc NextSequenceReceive(QueryNextSequenceReceiveRequest) returns (QueryNextSequenceReceiveResponse) {
-    option (google.api.http).get = "/ibc/core/channel/v1beta1/channels/{channel_id}/ports/{port_id}/next_sequence";
+    option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
+                                   "ports/{port_id}/next_sequence";
   }
 }
 
@@ -250,8 +257,8 @@ message QueryPacketReceiptRequest {
   uint64 sequence = 3;
 }
 
-// QueryPacketReceiptResponse defines the client query response for a packet receipt
-// which also includes a proof, and the height from which the proof was
+// QueryPacketReceiptResponse defines the client query response for a packet
+// receipt which also includes a proof, and the height from which the proof was
 // retrieved
 message QueryPacketReceiptResponse {
   // success flag for if receipt exists
@@ -294,6 +301,8 @@ message QueryPacketAcknowledgementsRequest {
   string channel_id = 2;
   // pagination request
   cosmos.base.query.v1beta1.PageRequest pagination = 3;
+  // list of packet sequences
+  repeated uint64 packet_commitment_sequences = 4;
 }
 
 // QueryPacketAcknowledgemetsResponse is the request type for the

--- a/pb-proto-java/src/main/proto/ibc/core/channel/v1/tx.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/channel/v1/tx.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/client.proto";
@@ -24,7 +25,8 @@ service Msg {
   // ChannelCloseInit defines a rpc handler method for MsgChannelCloseInit.
   rpc ChannelCloseInit(MsgChannelCloseInit) returns (MsgChannelCloseInitResponse);
 
-  // ChannelCloseConfirm defines a rpc handler method for MsgChannelCloseConfirm.
+  // ChannelCloseConfirm defines a rpc handler method for
+  // MsgChannelCloseConfirm.
   rpc ChannelCloseConfirm(MsgChannelCloseConfirm) returns (MsgChannelCloseConfirmResponse);
 
   // RecvPacket defines a rpc handler method for MsgRecvPacket.
@@ -61,8 +63,8 @@ message MsgChannelOpenTry {
   option (gogoproto.goproto_getters) = false;
 
   string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
-  // in the case of crossing hello's, when both chains call OpenInit, we need the channel identifier
-  // of the previous channel in state INIT
+  // in the case of crossing hello's, when both chains call OpenInit, we need
+  // the channel identifier of the previous channel in state INIT
   string                    previous_channel_id  = 2 [(gogoproto.moretags) = "yaml:\"previous_channel_id\""];
   Channel                   channel              = 3 [(gogoproto.nullable) = false];
   string                    counterparty_version = 4 [(gogoproto.moretags) = "yaml:\"counterparty_version\""];
@@ -108,7 +110,8 @@ message MsgChannelOpenConfirm {
   string signer = 5;
 }
 
-// MsgChannelOpenConfirmResponse defines the Msg/ChannelOpenConfirm response type.
+// MsgChannelOpenConfirmResponse defines the Msg/ChannelOpenConfirm response
+// type.
 message MsgChannelOpenConfirmResponse {}
 
 // MsgChannelCloseInit defines a msg sent by a Relayer to Chain A
@@ -139,7 +142,8 @@ message MsgChannelCloseConfirm {
   string signer = 5;
 }
 
-// MsgChannelCloseConfirmResponse defines the Msg/ChannelCloseConfirm response type.
+// MsgChannelCloseConfirmResponse defines the Msg/ChannelCloseConfirm response
+// type.
 message MsgChannelCloseConfirmResponse {}
 
 // MsgRecvPacket receives incoming IBC packet

--- a/pb-proto-java/src/main/proto/ibc/core/client/v1/client.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/client/v1/client.proto
@@ -1,10 +1,12 @@
 syntax = "proto3";
+
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/02-client/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
+import "cosmos/upgrade/v1beta1/upgrade.proto";
 
 // IdentifiedClientState defines a client state with an additional client
 // identifier field.
@@ -15,7 +17,8 @@ message IdentifiedClientState {
   google.protobuf.Any client_state = 2 [(gogoproto.moretags) = "yaml:\"client_state\""];
 }
 
-// ConsensusStateWithHeight defines a consensus state with an additional height field.
+// ConsensusStateWithHeight defines a consensus state with an additional height
+// field.
 message ConsensusStateWithHeight {
   // consensus state height
   Height height = 1 [(gogoproto.nullable) = false];
@@ -33,9 +36,10 @@ message ClientConsensusStates {
       [(gogoproto.moretags) = "yaml:\"consensus_states\"", (gogoproto.nullable) = false];
 }
 
-// ClientUpdateProposal is a governance proposal. If it passes, the client is
-// updated with the provided header. The update may fail if the header is not
-// valid given certain conditions specified by the client implementation.
+// ClientUpdateProposal is a governance proposal. If it passes, the substitute
+// client's latest consensus state is copied over to the subject client. The proposal
+// handler may fail if the subject and the substitute do not match in client and
+// chain parameters (with exception to latest height, frozen height, and chain-id).
 message ClientUpdateProposal {
   option (gogoproto.goproto_getters) = false;
   // the title of the update proposal
@@ -43,20 +47,42 @@ message ClientUpdateProposal {
   // the description of the proposal
   string description = 2;
   // the client identifier for the client to be updated if the proposal passes
-  string client_id = 3 [(gogoproto.moretags) = "yaml:\"client_id\""];
-  // the header used to update the client if the proposal passes
-  google.protobuf.Any header = 4;
+  string subject_client_id = 3 [(gogoproto.moretags) = "yaml:\"subject_client_id\""];
+  // the substitute client identifier for the client standing in for the subject
+  // client
+  string substitute_client_id = 4 [(gogoproto.moretags) = "yaml:\"substitute_client_id\""];
+}
+
+// UpgradeProposal is a gov Content type for initiating an IBC breaking
+// upgrade.
+message UpgradeProposal {
+  option (gogoproto.goproto_getters)  = false;
+  option (gogoproto.goproto_stringer) = false;
+  option (gogoproto.equal)            = true;
+
+  string                      title       = 1;
+  string                      description = 2;
+  cosmos.upgrade.v1beta1.Plan plan        = 3 [(gogoproto.nullable) = false];
+
+  // An UpgradedClientState must be provided to perform an IBC breaking upgrade.
+  // This will make the chain commit to the correct upgraded (self) client state
+  // before the upgrade occurs, so that connecting chains can verify that the
+  // new upgraded client is valid by verifying a proof on the previous version
+  // of the chain. This will allow IBC connections to persist smoothly across
+  // planned chain upgrades
+  google.protobuf.Any upgraded_client_state = 4 [(gogoproto.moretags) = "yaml:\"upgraded_client_state\""];
 }
 
 // Height is a monotonically increasing data type
 // that can be compared against another Height for the purposes of updating and
 // freezing clients
 //
-// Normally the RevisionHeight is incremented at each height while keeping RevisionNumber
-// the same. However some consensus algorithms may choose to reset the
-// height in certain conditions e.g. hard forks, state-machine breaking changes
-// In these cases, the RevisionNumber is incremented so that height continues to
-// be monitonically increasing even as the RevisionHeight gets reset
+// Normally the RevisionHeight is incremented at each height while keeping
+// RevisionNumber the same. However some consensus algorithms may choose to
+// reset the height in certain conditions e.g. hard forks, state-machine
+// breaking changes In these cases, the RevisionNumber is incremented so that
+// height continues to be monitonically increasing even as the RevisionHeight
+// gets reset
 message Height {
   option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;

--- a/pb-proto-java/src/main/proto/ibc/core/client/v1/genesis.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/client/v1/genesis.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/02-client/types";
 
 import "ibc/core/client/v1/client.proto";
 import "gogoproto/gogo.proto";
@@ -38,7 +39,8 @@ message GenesisMetadata {
   bytes value = 2;
 }
 
-// IdentifiedGenesisMetadata has the client metadata with the corresponding client id.
+// IdentifiedGenesisMetadata has the client metadata with the corresponding
+// client id.
 message IdentifiedGenesisMetadata {
   string                   client_id       = 1 [(gogoproto.moretags) = "yaml:\"client_id\""];
   repeated GenesisMetadata client_metadata = 2

--- a/pb-proto-java/src/main/proto/ibc/core/client/v1/query.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/client/v1/query.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.client.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/02-client/types";
 
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "ibc/core/client/v1/client.proto";
@@ -7,36 +10,50 @@ import "google/protobuf/any.proto";
 import "google/api/annotations.proto";
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types";
-
 // Query provides defines the gRPC querier service
 service Query {
   // ClientState queries an IBC light client.
   rpc ClientState(QueryClientStateRequest) returns (QueryClientStateResponse) {
-    option (google.api.http).get = "/ibc/core/client/v1beta1/client_states/{client_id}";
+    option (google.api.http).get = "/ibc/core/client/v1/client_states/{client_id}";
   }
 
   // ClientStates queries all the IBC light clients of a chain.
   rpc ClientStates(QueryClientStatesRequest) returns (QueryClientStatesResponse) {
-    option (google.api.http).get = "/ibc/core/client/v1beta1/client_states";
+    option (google.api.http).get = "/ibc/core/client/v1/client_states";
   }
 
   // ConsensusState queries a consensus state associated with a client state at
   // a given height.
   rpc ConsensusState(QueryConsensusStateRequest) returns (QueryConsensusStateResponse) {
-    option (google.api.http).get = "/ibc/core/client/v1beta1/consensus_states/{client_id}/revision/{revision_number}/"
+    option (google.api.http).get = "/ibc/core/client/v1/consensus_states/"
+                                   "{client_id}/revision/{revision_number}/"
                                    "height/{revision_height}";
   }
 
   // ConsensusStates queries all the consensus state associated with a given
   // client.
   rpc ConsensusStates(QueryConsensusStatesRequest) returns (QueryConsensusStatesResponse) {
-    option (google.api.http).get = "/ibc/core/client/v1beta1/consensus_states/{client_id}";
+    option (google.api.http).get = "/ibc/core/client/v1/consensus_states/{client_id}";
+  }
+
+  // Status queries the status of an IBC client.
+  rpc ClientStatus(QueryClientStatusRequest) returns (QueryClientStatusResponse) {
+    option (google.api.http).get = "/ibc/core/client/v1/client_status/{client_id}";
   }
 
   // ClientParams queries all parameters of the ibc client.
   rpc ClientParams(QueryClientParamsRequest) returns (QueryClientParamsResponse) {
-    option (google.api.http).get = "/ibc/client/v1beta1/params";
+    option (google.api.http).get = "/ibc/client/v1/params";
+  }
+
+  // UpgradedClientState queries an Upgraded IBC light client.
+  rpc UpgradedClientState(QueryUpgradedClientStateRequest) returns (QueryUpgradedClientStateResponse) {
+    option (google.api.http).get = "/ibc/core/client/v1/upgraded_client_states";
+  }
+
+  // UpgradedConsensusState queries an Upgraded IBC consensus state.
+  rpc UpgradedConsensusState(QueryUpgradedConsensusStateRequest) returns (QueryUpgradedConsensusStateResponse) {
+    option (google.api.http).get = "/ibc/core/client/v1/upgraded_consensus_states";
   }
 }
 
@@ -120,11 +137,48 @@ message QueryConsensusStatesResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryClientParamsRequest is the request type for the Query/ClientParams RPC method.
+// QueryClientStatusRequest is the request type for the Query/ClientStatus RPC
+// method
+message QueryClientStatusRequest {
+  // client unique identifier
+  string client_id = 1;
+}
+
+// QueryClientStatusResponse is the response type for the Query/ClientStatus RPC
+// method. It returns the current status of the IBC client.
+message QueryClientStatusResponse {
+  string status = 1;
+}
+
+// QueryClientParamsRequest is the request type for the Query/ClientParams RPC
+// method.
 message QueryClientParamsRequest {}
 
-// QueryClientParamsResponse is the response type for the Query/ClientParams RPC method.
+// QueryClientParamsResponse is the response type for the Query/ClientParams RPC
+// method.
 message QueryClientParamsResponse {
   // params defines the parameters of the module.
   Params params = 1;
+}
+
+// QueryUpgradedClientStateRequest is the request type for the
+// Query/UpgradedClientState RPC method
+message QueryUpgradedClientStateRequest {}
+
+// QueryUpgradedClientStateResponse is the response type for the
+// Query/UpgradedClientState RPC method.
+message QueryUpgradedClientStateResponse {
+  // client state associated with the request identifier
+  google.protobuf.Any upgraded_client_state = 1;
+}
+
+// QueryUpgradedConsensusStateRequest is the request type for the
+// Query/UpgradedConsensusState RPC method
+message QueryUpgradedConsensusStateRequest {}
+
+// QueryUpgradedConsensusStateResponse is the response type for the
+// Query/UpgradedConsensusState RPC method.
+message QueryUpgradedConsensusStateResponse {
+  // Consensus state associated with the request identifier
+  google.protobuf.Any upgraded_consensus_state = 1;
 }

--- a/pb-proto-java/src/main/proto/ibc/core/client/v1/tx.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/client/v1/tx.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
+
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/02-client/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
-import "ibc/core/client/v1/client.proto";
 
 // Msg defines the ibc/client Msg service.
 service Msg {
@@ -56,7 +56,8 @@ message MsgUpdateClient {
 // MsgUpdateClientResponse defines the Msg/UpdateClient response type.
 message MsgUpdateClientResponse {}
 
-// MsgUpgradeClient defines an sdk.Msg to upgrade an IBC client to a new client state
+// MsgUpgradeClient defines an sdk.Msg to upgrade an IBC client to a new client
+// state
 message MsgUpgradeClient {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
@@ -65,7 +66,8 @@ message MsgUpgradeClient {
   string client_id = 1 [(gogoproto.moretags) = "yaml:\"client_id\""];
   // upgraded client state
   google.protobuf.Any client_state = 2 [(gogoproto.moretags) = "yaml:\"client_state\""];
-  // upgraded consensus state, only contains enough information to serve as a basis of trust in update logic
+  // upgraded consensus state, only contains enough information to serve as a
+  // basis of trust in update logic
   google.protobuf.Any consensus_state = 3 [(gogoproto.moretags) = "yaml:\"consensus_state\""];
   // proof that old chain committed to new client
   bytes proof_upgrade_client = 4 [(gogoproto.moretags) = "yaml:\"proof_upgrade_client\""];
@@ -92,5 +94,6 @@ message MsgSubmitMisbehaviour {
   string signer = 3;
 }
 
-// MsgSubmitMisbehaviourResponse defines the Msg/SubmitMisbehaviour response type.
+// MsgSubmitMisbehaviourResponse defines the Msg/SubmitMisbehaviour response
+// type.
 message MsgSubmitMisbehaviourResponse {}

--- a/pb-proto-java/src/main/proto/ibc/core/commitment/v1/commitment.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/commitment/v1/commitment.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.commitment.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/23-commitment/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/23-commitment/types";
 
 import "gogoproto/gogo.proto";
 import "confio/proofs.proto";

--- a/pb-proto-java/src/main/proto/ibc/core/connection/v1/connection.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/connection/v1/connection.proto
@@ -1,13 +1,14 @@
 syntax = "proto3";
+
 package ibc.core.connection.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/03-connection/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/commitment/v1/commitment.proto";
 
 // ICS03 - Connection Data Structures as defined in
-// https://github.com/cosmos/ics/tree/master/spec/ics-003-connection-semantics#data-structures
+// https://github.com/cosmos/ibc/blob/master/spec/core/ics-003-connection-semantics#data-structures
 
 // ConnectionEnd defines a stateful object on a chain connected to another
 // separate one.
@@ -24,8 +25,9 @@ message ConnectionEnd {
   State state = 3;
   // counterparty chain associated with this connection.
   Counterparty counterparty = 4 [(gogoproto.nullable) = false];
-  // delay period that must pass before a consensus state can be used for packet-verification
-  // NOTE: delay period logic is only implemented by some clients.
+  // delay period that must pass before a consensus state can be used for
+  // packet-verification NOTE: delay period logic is only implemented by some
+  // clients.
   uint64 delay_period = 5 [(gogoproto.moretags) = "yaml:\"delay_period\""];
 }
 
@@ -101,4 +103,12 @@ message Version {
   string identifier = 1;
   // list of features compatible with the specified identifier
   repeated string features = 2;
+}
+
+// Params defines the set of Connection parameters.
+message Params {
+  // maximum expected time per block (in nanoseconds), used to enforce block delay. This parameter should reflect the
+  // largest amount of time that the chain might reasonably take to produce the next block under normal operating
+  // conditions. A safe choice is 3-5x the expected time per block.
+  uint64 max_expected_time_per_block = 1 [(gogoproto.moretags) = "yaml:\"max_expected_time_per_block\""];
 }

--- a/pb-proto-java/src/main/proto/ibc/core/connection/v1/genesis.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/connection/v1/genesis.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.connection.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/03-connection/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/connection/v1/connection.proto";
@@ -13,4 +14,5 @@ message GenesisState {
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"client_connection_paths\""];
   // the sequence for the next generated connection identifier
   uint64 next_connection_sequence = 3 [(gogoproto.moretags) = "yaml:\"next_connection_sequence\""];
+  Params params                   = 4 [(gogoproto.nullable) = false];
 }

--- a/pb-proto-java/src/main/proto/ibc/core/connection/v1/query.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/connection/v1/query.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.connection.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types";
 
 import "gogoproto/gogo.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
@@ -8,36 +11,34 @@ import "ibc/core/connection/v1/connection.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/any.proto";
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/03-connection/types";
-
 // Query provides defines the gRPC querier service
 service Query {
   // Connection queries an IBC connection end.
   rpc Connection(QueryConnectionRequest) returns (QueryConnectionResponse) {
-    option (google.api.http).get = "/ibc/core/connection/v1beta1/connections/{connection_id}";
+    option (google.api.http).get = "/ibc/core/connection/v1/connections/{connection_id}";
   }
 
   // Connections queries all the IBC connections of a chain.
   rpc Connections(QueryConnectionsRequest) returns (QueryConnectionsResponse) {
-    option (google.api.http).get = "/ibc/core/connection/v1beta1/connections";
+    option (google.api.http).get = "/ibc/core/connection/v1/connections";
   }
 
   // ClientConnections queries the connection paths associated with a client
   // state.
   rpc ClientConnections(QueryClientConnectionsRequest) returns (QueryClientConnectionsResponse) {
-    option (google.api.http).get = "/ibc/core/connection/v1beta1/client_connections/{client_id}";
+    option (google.api.http).get = "/ibc/core/connection/v1/client_connections/{client_id}";
   }
 
   // ConnectionClientState queries the client state associated with the
   // connection.
   rpc ConnectionClientState(QueryConnectionClientStateRequest) returns (QueryConnectionClientStateResponse) {
-    option (google.api.http).get = "/ibc/core/connection/v1beta1/connections/{connection_id}/client_state";
+    option (google.api.http).get = "/ibc/core/connection/v1/connections/{connection_id}/client_state";
   }
 
   // ConnectionConsensusState queries the consensus state associated with the
   // connection.
   rpc ConnectionConsensusState(QueryConnectionConsensusStateRequest) returns (QueryConnectionConsensusStateResponse) {
-    option (google.api.http).get = "/ibc/core/connection/v1beta1/connections/{connection_id}/consensus_state/"
+    option (google.api.http).get = "/ibc/core/connection/v1/connections/{connection_id}/consensus_state/"
                                    "revision/{revision_number}/height/{revision_height}";
   }
 }

--- a/pb-proto-java/src/main/proto/ibc/core/connection/v1/tx.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/connection/v1/tx.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.connection.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/03-connection/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
@@ -19,7 +20,8 @@ service Msg {
   // ConnectionOpenAck defines a rpc handler method for MsgConnectionOpenAck.
   rpc ConnectionOpenAck(MsgConnectionOpenAck) returns (MsgConnectionOpenAckResponse);
 
-  // ConnectionOpenConfirm defines a rpc handler method for MsgConnectionOpenConfirm.
+  // ConnectionOpenConfirm defines a rpc handler method for
+  // MsgConnectionOpenConfirm.
   rpc ConnectionOpenConfirm(MsgConnectionOpenConfirm) returns (MsgConnectionOpenConfirmResponse);
 }
 
@@ -36,7 +38,8 @@ message MsgConnectionOpenInit {
   string       signer       = 5;
 }
 
-// MsgConnectionOpenInitResponse defines the Msg/ConnectionOpenInit response type.
+// MsgConnectionOpenInitResponse defines the Msg/ConnectionOpenInit response
+// type.
 message MsgConnectionOpenInitResponse {}
 
 // MsgConnectionOpenTry defines a msg sent by a Relayer to try to open a
@@ -46,8 +49,8 @@ message MsgConnectionOpenTry {
   option (gogoproto.goproto_getters) = false;
 
   string client_id = 1 [(gogoproto.moretags) = "yaml:\"client_id\""];
-  // in the case of crossing hello's, when both chains call OpenInit, we need the connection identifier
-  // of the previous connection in state INIT
+  // in the case of crossing hello's, when both chains call OpenInit, we need
+  // the connection identifier of the previous connection in state INIT
   string                    previous_connection_id = 2 [(gogoproto.moretags) = "yaml:\"previous_connection_id\""];
   google.protobuf.Any       client_state           = 3 [(gogoproto.moretags) = "yaml:\"client_state\""];
   Counterparty              counterparty           = 4 [(gogoproto.nullable) = false];
@@ -111,5 +114,6 @@ message MsgConnectionOpenConfirm {
   string signer = 4;
 }
 
-// MsgConnectionOpenConfirmResponse defines the Msg/ConnectionOpenConfirm response type.
+// MsgConnectionOpenConfirmResponse defines the Msg/ConnectionOpenConfirm
+// response type.
 message MsgConnectionOpenConfirmResponse {}

--- a/pb-proto-java/src/main/proto/ibc/core/types/v1/genesis.proto
+++ b/pb-proto-java/src/main/proto/ibc/core/types/v1/genesis.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.core.types.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/core/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/genesis.proto";

--- a/pb-proto-java/src/main/proto/ibc/lightclients/localhost/v1/localhost.proto
+++ b/pb-proto-java/src/main/proto/ibc/lightclients/localhost/v1/localhost.proto
@@ -1,10 +1,11 @@
 syntax = "proto3";
+
 package ibc.lightclients.localhost.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v2/modules/light-clients/09-localhost/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/client.proto";
-
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/09-localhost/types";
 
 // ClientState defines a loopback (localhost) client. It requires (read-only)
 // access to keys outside the client prefix.

--- a/pb-proto-java/src/main/proto/ibc/lightclients/solomachine/v1/solomachine.proto
+++ b/pb-proto-java/src/main/proto/ibc/lightclients/solomachine/v1/solomachine.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.lightclients.solomachine.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/06-solomachine/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/core/02-client/legacy/v100";
 
 import "ibc/core/connection/v1/connection.proto";
 import "ibc/core/channel/v1/channel.proto";
@@ -22,14 +23,16 @@ message ClientState {
   bool allow_update_after_proposal = 4 [(gogoproto.moretags) = "yaml:\"allow_update_after_proposal\""];
 }
 
-// ConsensusState defines a solo machine consensus state. The sequence of a consensus state
-// is contained in the "height" key used in storing the consensus state.
+// ConsensusState defines a solo machine consensus state. The sequence of a
+// consensus state is contained in the "height" key used in storing the
+// consensus state.
 message ConsensusState {
   option (gogoproto.goproto_getters) = false;
   // public key of the solo machine
   google.protobuf.Any public_key = 1 [(gogoproto.moretags) = "yaml:\"public_key\""];
-  // diversifier allows the same public key to be re-used across different solo machine clients
-  // (potentially on different chains) without being considered misbehaviour.
+  // diversifier allows the same public key to be re-used across different solo
+  // machine clients (potentially on different chains) without being considered
+  // misbehaviour.
   string diversifier = 2;
   uint64 timestamp   = 3;
 }
@@ -86,8 +89,8 @@ message SignBytes {
   bytes data = 5;
 }
 
-// DataType defines the type of solo machine proof being created. This is done to preserve uniqueness of different
-// data sign byte encodings.
+// DataType defines the type of solo machine proof being created. This is done
+// to preserve uniqueness of different data sign byte encodings.
 enum DataType {
   option (gogoproto.goproto_enum_prefix) = false;
 

--- a/pb-proto-java/src/main/proto/ibc/lightclients/tendermint/v1/tendermint.proto
+++ b/pb-proto-java/src/main/proto/ibc/lightclients/tendermint/v1/tendermint.proto
@@ -1,7 +1,8 @@
 syntax = "proto3";
+
 package ibc.lightclients.tendermint.v1;
 
-option go_package = "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/07-tendermint/types";
+option go_package = "github.com/cosmos/ibc-go/v2/modules/light-clients/07-tendermint/types";
 
 import "tendermint/types/validator.proto";
 import "tendermint/types/types.proto";
@@ -43,10 +44,12 @@ message ClientState {
   repeated ics23.ProofSpec proof_specs = 8 [(gogoproto.moretags) = "yaml:\"proof_specs\""];
 
   // Path at which next upgraded client will be committed.
-  // Each element corresponds to the key for a single CommitmentProof in the chained proof.
-  // NOTE: ClientState must stored under `{upgradePath}/{upgradeHeight}/clientState`
-  // ConsensusState must be stored under `{upgradepath}/{upgradeHeight}/consensusState`
-  // For SDK chains using the default upgrade module, upgrade_path should be []string{"upgrade", "upgradedIBCState"}`
+  // Each element corresponds to the key for a single CommitmentProof in the
+  // chained proof. NOTE: ClientState must stored under
+  // `{upgradePath}/{upgradeHeight}/clientState` ConsensusState must be stored
+  // under `{upgradepath}/{upgradeHeight}/consensusState` For SDK chains using
+  // the default upgrade module, upgrade_path should be []string{"upgrade",
+  // "upgradedIBCState"}`
   repeated string upgrade_path = 9 [(gogoproto.moretags) = "yaml:\"upgrade_path\""];
 
   // This flag, when set to true, will allow governance to recover a client
@@ -104,7 +107,8 @@ message Header {
   .tendermint.types.ValidatorSet trusted_validators = 4 [(gogoproto.moretags) = "yaml:\"trusted_validators\""];
 }
 
-// Fraction defines the protobuf message type for tmmath.Fraction that only supports positive values.
+// Fraction defines the protobuf message type for tmmath.Fraction that only
+// supports positive values.
 message Fraction {
   uint64 numerator   = 1;
   uint64 denominator = 2;

--- a/pb-proto-java/src/main/proto/provenance/marker/v1/authz.proto
+++ b/pb-proto-java/src/main/proto/provenance/marker/v1/authz.proto
@@ -4,16 +4,16 @@ import "gogoproto/gogo.proto";
 import "cosmos_proto/cosmos.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/provenance-io/provenance/x/marker/types";
+option go_package          = "github.com/provenance-io/provenance/x/marker/types";
 option java_package        = "io.provenance.marker.v1";
 option java_multiple_files = true;
 
 // MarkerTransferAuthorization gives the grantee permissions to execute
 // a marker transfer on behalf of the granter's account.
 message MarkerTransferAuthorization {
-    option (cosmos_proto.implements_interface) = "Authorization";
+  option (cosmos_proto.implements_interface) = "Authorization";
 
-    // transfer_limit is the total amount the grantee can transfer
-    repeated cosmos.base.v1beta1.Coin transfer_limit = 1
-    [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
+  // transfer_limit is the total amount the grantee can transfer
+  repeated cosmos.base.v1beta1.Coin transfer_limit = 1
+      [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"];
 }


### PR DESCRIPTION
* Bump cosmos to 0.45.0
* Bump wasmd to 0.22.0 and point it back to upstream. (https://github.com/provenance-io/provenance/issues/479)
* Bump PbProto to 1.8.0-rc2